### PR TITLE
main structure for logging and shell operations set up

### DIFF
--- a/include/bootstrap.h
+++ b/include/bootstrap.h
@@ -32,6 +32,8 @@ namespace domain::images::http
 namespace domain::containers
 {
     class container_repository;
+    class terminal_listener;
+    class virtual_terminal;
     class runtime;
 };
 using namespace core::commands;
@@ -45,6 +47,11 @@ public:
     void setup();
     void start();
     void stop();
+
+private:
+    std::unique_ptr<domain::containers::virtual_terminal> create_virtual_terminal(
+        const std::string &identifier,
+        domain::containers::terminal_listener &listener);
 
 private:
     std::shared_ptr<command_handler_registry> registry;

--- a/include/core/commands/command_handler_registry.h
+++ b/include/core/commands/command_handler_registry.h
@@ -20,7 +20,7 @@ namespace core::connections
 using namespace core::connections;
 namespace core::commands
 {
-    typedef std::function<std::unique_ptr<command_handler>(connection &)> command_handler_provider;
+    typedef std::function<std::shared_ptr<command_handler>(connection &)> command_handler_provider;
     class command_handler_registry
     {
     public:

--- a/include/core/connections/connection.h
+++ b/include/core/connections/connection.h
@@ -56,7 +56,7 @@ namespace core::connections
         std::deque<std::vector<uint8_t>> sending_queue;
         std::shared_ptr<core::commands::command_handler_registry> command_handler_registry;
         removal_trigger_callback removal_callback;
-        std::unique_ptr<core::commands::command_handler> command_handler;
+        std::shared_ptr<core::commands::command_handler> command_handler;
         std::shared_ptr<spdlog::logger> logger;
     };
 };

--- a/include/domain/containers/container.h
+++ b/include/domain/containers/container.h
@@ -44,7 +44,6 @@ namespace domain::containers
         virtual void initialize() = 0;
         virtual ~container() = default;
         virtual void start() = 0;
-        virtual void resize(int columns, int rows) = 0;
         virtual void register_listener(std::shared_ptr<container_listener> operation_listener) = 0;
 
     protected:

--- a/include/domain/containers/freebsd/freebsd_container.h
+++ b/include/domain/containers/freebsd/freebsd_container.h
@@ -54,7 +54,7 @@ namespace domain::containers::freebsd
         std::vector<uint8_t> buffer;
         std::unique_ptr<asio::posix::stream_descriptor> stream;
         std::shared_ptr<spdlog::logger> logger;
-        std::map<listener_category, std::shared_ptr<container_listener>> operation_listeners;
+        std::map<listener_category, std::weak_ptr<container_listener>> operation_listeners;
     };
 }
 #endif // __DAEMON_DOMAIN_CONTAINERS_FREEBSD_CONTAINER_IMPLEMENTATION__

--- a/include/domain/containers/freebsd/freebsd_container.h
+++ b/include/domain/containers/freebsd/freebsd_container.h
@@ -32,7 +32,6 @@ namespace domain::containers::freebsd
         void initialize() override;
         virtual ~freebsd_container() override;
         void start() override;
-        void resize(int columns, int rows) override;
         void register_listener(std::shared_ptr<container_listener> operation_listener) override;
 
     private:

--- a/include/domain/containers/freebsd/freebsd_terminal.h
+++ b/include/domain/containers/freebsd/freebsd_terminal.h
@@ -1,0 +1,56 @@
+#ifndef __DAEMON_DOMAIN_CONTAINERS_FREEBSD_VIRTUAL_TERMINAL__
+#define __DAEMON_DOMAIN_CONTAINERS_FREEBSD_VIRTUAL_TERMINAL__
+
+#include <domain/containers/virtual_terminal.h>
+#include <asio/posix/stream_descriptor.hpp>
+#include <string>
+namespace asio
+{
+    class io_context;
+};
+
+namespace spdlog
+{
+    class logger;
+};
+
+namespace domain::containers
+{
+    class terminal_listener;
+};
+
+namespace domain::containers::freebsd
+{
+    class freebsd_terminal : public virtual_terminal
+    {
+        const int WRITE_BUFFER_SIZE = 1024;
+
+    public:
+        freebsd_terminal(asio::io_context &context,
+                         const std::string &identifier,
+                         terminal_listener &listener);
+        virtual ~freebsd_terminal();
+        std::error_code initialize() override;
+        void start() override;
+        void resize(uint32_t columns, uint32_t rows) override;
+        void write(const std::vector<uint8_t> &content) override;
+
+    private:
+        void read_from_shell();
+        void wait_to_read_from_shell();
+        bool setup_pipe(int fd);
+        void clean();
+
+    private:
+        asio::io_context &context;
+        const std::string &identifier;
+        terminal_listener &listener;
+        int file_descriptor;
+        pid_t process_identifier;
+        std::vector<uint8_t> buffer;
+        std::unique_ptr<asio::posix::stream_descriptor> in;
+        std::unique_ptr<asio::posix::stream_descriptor> out;
+        std::shared_ptr<spdlog::logger> logger;
+    };
+}
+#endif // __DAEMON_DOMAIN_CONTAINERS_FREEBSD_VIRTUAL_TERMINAL__

--- a/include/domain/containers/logging_handler.h
+++ b/include/domain/containers/logging_handler.h
@@ -1,6 +1,7 @@
 #ifndef __DAEMON_DOMAIN_CONTAINERS_LOGGING_HANDLER__
 #define __DAEMON_DOMAIN_CONTAINERS_LOGGING_HANDLER__
 #include <core/commands/command_handler.h>
+#include <domain/containers/container_listener.h>
 #include <memory>
 namespace spdlog
 {
@@ -10,8 +11,11 @@ namespace spdlog
 namespace domain::containers
 {
     class runtime;
+    class container;
     class container_repository;
-    class logging_handler : public core::commands::command_handler
+    class logging_handler : public core::commands::command_handler,
+                            public container_listener,
+                            std::enable_shared_from_this<logging_handler>
     {
 
     public:
@@ -21,11 +25,16 @@ namespace domain::containers
             std::shared_ptr<runtime> runtime_ptr);
         virtual ~logging_handler();
         void on_order_received(const std::vector<uint8_t> &payload) override;
+        void on_operation_initialization() override;
+        void on_operation_output(const std::vector<uint8_t> &content) override;
+        void on_operation_failure(const std::error_code &error) override;
+        listener_category type() override;
         void on_connection_closed(const std::error_code &error) override;
 
     private:
         std::shared_ptr<container_repository> repository;
         std::shared_ptr<runtime> runtime_ptr;
+        std::shared_ptr<container> container_ptr;
         std::shared_ptr<spdlog::logger> logger;
     };
 }

--- a/include/domain/containers/logging_handler.h
+++ b/include/domain/containers/logging_handler.h
@@ -1,0 +1,33 @@
+#ifndef __DAEMON_DOMAIN_CONTAINERS_LOGGING_HANDLER__
+#define __DAEMON_DOMAIN_CONTAINERS_LOGGING_HANDLER__
+#include <core/commands/command_handler.h>
+#include <memory>
+namespace spdlog
+{
+    class logger;
+};
+
+namespace domain::containers
+{
+    class runtime;
+    class container_repository;
+    class logging_handler : public core::commands::command_handler
+    {
+
+    public:
+        logging_handler(
+            core::connections::connection &connection,
+            std::shared_ptr<container_repository> repository,
+            std::shared_ptr<runtime> runtime_ptr);
+        virtual ~logging_handler();
+        void on_order_received(const std::vector<uint8_t> &payload) override;
+        void on_connection_closed(const std::error_code &error) override;
+
+    private:
+        std::shared_ptr<container_repository> repository;
+        std::shared_ptr<runtime> runtime_ptr;
+        std::shared_ptr<spdlog::logger> logger;
+    };
+}
+
+#endif // __DAEMON_DOMAIN_CONTAINERS_LOGGING_HANDLER__

--- a/include/domain/containers/orders.h
+++ b/include/domain/containers/orders.h
@@ -25,7 +25,7 @@ namespace domain::containers
         return msgpack::unpack<container_creation_order>(content);
     }
 
-    struct container_start_order
+    struct container_term_order
     {
         std::string term;
         template <class T>
@@ -35,9 +35,9 @@ namespace domain::containers
         }
     };
 
-    inline container_start_order unpack_container_start_order(const std::vector<uint8_t> &content)
+    inline container_term_order unpack_container_term_order(const std::vector<uint8_t> &content)
     {
-        return msgpack::unpack<container_start_order>(content);
+        return msgpack::unpack<container_term_order>(content);
     }
     namespace shell
     {

--- a/include/domain/containers/orders.h
+++ b/include/domain/containers/orders.h
@@ -39,6 +39,27 @@ namespace domain::containers
     {
         return msgpack::unpack<container_start_order>(content);
     }
+    namespace shell
+    {
+        constexpr uint8_t start_session = 0x00;
+        constexpr uint8_t terminal_size = 0x01;
+        constexpr uint8_t terminal_feed = 0x02;
+    }
+    struct container_shell_order
+    {
+        uint8_t type;
+        std::vector<uint8_t> data;
+        template <class T>
+        void pack(T &pack)
+        {
+            pack(type, data);
+        }
+    };
+
+    inline container_shell_order unpack_container_shell_order(const std::vector<uint8_t> &content)
+    {
+        return msgpack::unpack<container_shell_order>(content);
+    }
 }
 
 #endif // __DAEMON_DOMAIN_CONTAINERS_ORDERS__

--- a/include/domain/containers/repository.h
+++ b/include/domain/containers/repository.h
@@ -12,7 +12,8 @@ namespace domain::containers
     public:
         virtual std::optional<domain::images::image_details> fetch_image_details(const std::string &registry, const std::string &name, const std::string &tag) = 0;
         virtual std::optional<container_details> fetch(const std::string &identifier) = 0;
-        virtual std::optional<container_details> first_match(const std::string& query) = 0;
+        virtual std::optional<container_details> first_match(const std::string &query) = 0;
+        virtual std::optional<std::string> first_identifier_match(const std::string &query) = 0;
         virtual std::error_code save(const container_properties &properties) = 0;
     };
 }

--- a/include/domain/containers/runtime.h
+++ b/include/domain/containers/runtime.h
@@ -31,6 +31,7 @@ namespace domain::containers
         virtual ~runtime();
         void create_container(operation_details details);
         void remove_container(std::string &identifier);
+        std::shared_ptr<container> fetch_container(const std::string &identifier);
         void container_initialized(const std::string &identifier) override;
         void container_started(const std::string &identifier) override;
         void container_failed(const std::string &identifier, const std::error_code &error) override;

--- a/include/domain/containers/shell_handler.h
+++ b/include/domain/containers/shell_handler.h
@@ -1,0 +1,41 @@
+#ifndef __DAEMON_DOMAIN_CONTAINERS_SHELL_HANDLER__
+#define __DAEMON_DOMAIN_CONTAINERS_SHELL_HANDLER__
+
+#include <core/commands/command_handler.h>
+#include <domain/containers/terminal_listener.h>
+#include <functional>
+#include <memory>
+
+namespace spdlog
+{
+    class logger;
+};
+
+namespace domain::containers
+{
+    class container_repository;
+    class virtual_terminal;
+
+    typedef std::function<std::unique_ptr<virtual_terminal>(const std::string &, terminal_listener &)> virtual_terminal_provider;
+    class shell_handler : public core::commands::command_handler, public terminal_listener
+    {
+    public:
+        explicit shell_handler(core::connections::connection &connection,
+                      std::shared_ptr<container_repository> repository,
+                      virtual_terminal_provider provider);
+        virtual ~shell_handler();
+        void on_order_received(const std::vector<uint8_t> &payload) override;
+        void on_connection_closed(const std::error_code &error) override;
+        void on_terminal_initialized() override;
+        void on_terminal_data_received(const std::vector<uint8_t> &content) override;
+        void on_terminal_error(const std::error_code &error) override;
+
+    private:
+        std::shared_ptr<container_repository> repository;
+        virtual_terminal_provider provider;
+        std::unique_ptr<virtual_terminal> terminal;
+        std::shared_ptr<spdlog::logger> logger;
+    };
+}
+
+#endif // __DAEMON_DOMAIN_CONTAINERS_SHELL_HANDLER__

--- a/include/domain/containers/sql_repository.h
+++ b/include/domain/containers/sql_repository.h
@@ -17,7 +17,8 @@ namespace domain::containers
         virtual ~sql_container_repository();
         std::optional<domain::images::image_details> fetch_image_details(const std::string &registry, const std::string &name, const std::string &tag) override;
         std::optional<container_details> fetch(const std::string &identifier) override;
-        std::optional<container_details> first_match(const std::string& query) override;
+        std::optional<container_details> first_match(const std::string &query) override;
+        std::optional<std::string> first_identifier_match(const std::string &query) override;
         std::error_code save(const container_properties &properties) override;
 
     private:

--- a/include/domain/containers/terminal_listener.h
+++ b/include/domain/containers/terminal_listener.h
@@ -1,0 +1,18 @@
+#ifndef __DAEMON_DOMAIN_CONTAINERS_TERMINAL_LISTENER__
+#define __DAEMON_DOMAIN_CONTAINERS_TERMINAL_LISTENER__
+
+#include <cstdint>
+#include <vector>
+#include <system_error>
+
+namespace domain::containers
+{
+    class terminal_listener
+    {
+    public:
+        virtual void on_terminal_initialized() = 0;
+        virtual void on_terminal_data_received(const std::vector<uint8_t> &content) = 0;
+        virtual void on_terminal_error(const std::error_code &err) = 0;
+    };
+}
+#endif // __DAEMON_DOMAIN_CONTAINERS_TERMINAL_LISTENER__

--- a/include/domain/containers/virtual_terminal.h
+++ b/include/domain/containers/virtual_terminal.h
@@ -1,6 +1,7 @@
 #ifndef __DAEMON_DOMAIN_CONTAINERS_VIRTUAL_TERMINAL__
 #define __DAEMON_DOMAIN_CONTAINERS_VIRTUAL_TERMINAL__
 
+#include <system_error>
 #include <cstdint>
 #include <vector>
 
@@ -10,6 +11,7 @@ namespace domain::containers
     {
     public:
         virtual ~virtual_terminal() = default;
+        virtual std::error_code initialize() = 0;
         virtual void start() = 0;
         virtual void resize(uint32_t columns, uint32_t rows) = 0;
         virtual void write(const std::vector<uint8_t> &content) = 0;

--- a/include/domain/containers/virtual_terminal.h
+++ b/include/domain/containers/virtual_terminal.h
@@ -1,0 +1,18 @@
+#ifndef __DAEMON_DOMAIN_CONTAINERS_VIRTUAL_TERMINAL__
+#define __DAEMON_DOMAIN_CONTAINERS_VIRTUAL_TERMINAL__
+
+#include <cstdint>
+#include <vector>
+
+namespace domain::containers
+{
+    class virtual_terminal
+    {
+    public:
+        virtual ~virtual_terminal() = default;
+        virtual void start() = 0;
+        virtual void resize(uint32_t columns, uint32_t rows) = 0;
+        virtual void write(const std::vector<uint8_t> &content) = 0;
+    };
+}
+#endif // __DAEMON_DOMAIN_CONTAINERS_VIRTUAL_TERMINAL__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(daemon
                 domain/containers/sql_repository.cc
                 #containers::freebsd
                 domain/containers/freebsd/freebsd_container.cc
+                domain/containers/freebsd/freebsd_terminal.cc
                 # networking
                 domain/networking/asio_address_provider.cc
                 domain/networking/virtual_network_provider.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ add_executable(daemon
                 domain/containers/runtime.cc 
                 domain/containers/creation_handler.cc
                 domain/containers/start_handler.cc
+                domain/containers/logging_handler.cc
+                domain/containers/shell_handler.cc
                 domain/containers/sql_repository.cc
                 #containers::freebsd
                 domain/containers/freebsd/freebsd_container.cc

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -18,6 +18,10 @@
 #include <domain/containers/runtime.h>
 #include <asio/io_context.hpp>
 
+#if defined(__FreeBSD__)
+#include <domain/containers/freebsd/freebsd_terminal.h>
+#endif
+
 using namespace domain::images;
 using namespace domain::containers;
 
@@ -79,7 +83,7 @@ void bootstrap::setup()
                             const std::string &identifier,
                             terminal_listener &listener) -> std::unique_ptr<virtual_terminal>
         {
-          return {};
+          return create_virtual_terminal(identifier, listener);
         };
         return std::make_shared<shell_handler>(conn, container_repository, provider);
       });
@@ -99,6 +103,16 @@ void bootstrap::stop()
 {
   acceptor->stop();
 }
+
+#if defined(__FreeBSD__)
+std::unique_ptr<virtual_terminal> bootstrap::create_virtual_terminal(
+    const std::string &identifier,
+    terminal_listener &listener)
+{
+  return std::make_unique<freebsd::freebsd_terminal>(context, identifier, listener);
+}
+#endif
+
 bootstrap::~bootstrap()
 {
 }

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -37,43 +37,43 @@ void bootstrap::setup()
   registry->add_handler(
       operation_target::image,
       request_operation::list,
-      [&](connection &conn) -> std::unique_ptr<command_handler>
+      [&](connection &conn) -> std::shared_ptr<command_handler>
       {
-        return std::make_unique<list_handler>(conn);
+        return std::make_shared<list_handler>(conn);
       });
   registry->add_handler(
       operation_target::image,
       request_operation::build,
-      [this](connection &conn) -> std::unique_ptr<command_handler>
+      [this](connection &conn) -> std::shared_ptr<command_handler>
       {
-        return std::make_unique<build_handler>(conn, image_repository, client, context);
+        return std::make_shared<build_handler>(conn, image_repository, client, context);
       });
   registry->add_handler(
       operation_target::image,
       request_operation::import,
-      [this](connection &conn) -> std::unique_ptr<command_handler>
+      [this](connection &conn) -> std::shared_ptr<command_handler>
       {
-        return std::make_unique<import_handler>(conn, image_repository);
+        return std::make_shared<import_handler>(conn, image_repository);
       });
   registry->add_handler(
       operation_target::container,
       request_operation::build,
-      [this](connection &conn) -> std::unique_ptr<command_handler>
+      [this](connection &conn) -> std::shared_ptr<command_handler>
       {
         creation_configuration cfg{containers_folder, images_folder};
-        return std::make_unique<creation_handler>(conn, cfg, container_repository);
+        return std::make_shared<creation_handler>(conn, cfg, container_repository);
       });
   registry->add_handler(
       operation_target::container,
       request_operation::start,
-      [this](connection &conn) -> std::unique_ptr<command_handler>
+      [this](connection &conn) -> std::shared_ptr<command_handler>
       {
-        return std::make_unique<start_handler>(conn, container_repository, runtime, containers_folder);
+        return std::make_shared<start_handler>(conn, container_repository, runtime, containers_folder);
       });
   registry->add_handler(
       operation_target::container,
       request_operation::shell,
-      [this](connection &conn) -> std::unique_ptr<command_handler>
+      [this](connection &conn) -> std::shared_ptr<command_handler>
       {
         auto provider = [this](
                             const std::string &identifier,
@@ -81,14 +81,14 @@ void bootstrap::setup()
         {
           return {};
         };
-        return std::make_unique<shell_handler>(conn, container_repository, provider);
+        return std::make_shared<shell_handler>(conn, container_repository, provider);
       });
   registry->add_handler(
       operation_target::container,
       request_operation::logs,
-      [this](connection &conn) -> std::unique_ptr<command_handler>
+      [this](connection &conn) -> std::shared_ptr<command_handler>
       {
-        return std::make_unique<logging_handler>(conn, container_repository, runtime);
+        return std::make_shared<logging_handler>(conn, container_repository, runtime);
       });
 }
 void bootstrap::start()

--- a/src/domain/containers/freebsd/freebsd_container.cc
+++ b/src/domain/containers/freebsd/freebsd_container.cc
@@ -72,18 +72,6 @@ namespace domain::containers::freebsd
                              }
                          }); });
     }
-    void freebsd_container::resize(int columns, int rows)
-    {
-        struct winsize size;
-        size.ws_col = (unsigned short)columns;
-        size.ws_row = (unsigned short)rows;
-        size.ws_xpixel = 0;
-        size.ws_ypixel = 0;
-        if (ioctl(file_descriptor, TIOCSWINSZ, &size) < 0)
-        {
-            listener.container_failed(details.identifier, std::error_code(errno, std::system_category()));
-        }
-    }
     void freebsd_container::register_listener(std::shared_ptr<container_listener> operation_listener)
     {
         if (auto pos = operation_listeners.find(operation_listener->type()); pos != operation_listeners.end())

--- a/src/domain/containers/freebsd/freebsd_container.cc
+++ b/src/domain/containers/freebsd/freebsd_container.cc
@@ -262,26 +262,36 @@ namespace domain::containers::freebsd
     {
         if (auto pos = operation_listeners.find(listener_category::observer); pos != operation_listeners.end())
         {
-            auto operation_listener = pos->second;
-            operation_listener->on_operation_failure(error);
+            if (auto operation_listener = pos->second.lock(); operation_listener)
+            {
+                operation_listener->on_operation_failure(error);
+            }
         }
         else if (auto pos = operation_listeners.find(listener_category::runtime); pos != operation_listeners.end())
         {
-            auto operation_listener = pos->second;
-            operation_listener->on_operation_failure(error);
+            if (auto operation_listener = pos->second.lock(); operation_listener)
+            {
+                operation_listener->on_operation_failure(error);
+            }
         }
     }
     void freebsd_container::on_operation_output(const std::vector<uint8_t> &content)
     {
         if (auto pos = operation_listeners.find(listener_category::observer); pos != operation_listeners.end())
         {
-            auto operation_listener = pos->second;
-            operation_listener->on_operation_output(content);
+
+            if (auto operation_listener = pos->second.lock(); operation_listener)
+            {
+                operation_listener->on_operation_output(content);
+            }
         }
         else if (auto pos = operation_listeners.find(listener_category::runtime); pos != operation_listeners.end())
         {
-            auto operation_listener = pos->second;
-            operation_listener->on_operation_output(content);
+
+            if (auto operation_listener = pos->second.lock(); operation_listener)
+            {
+                operation_listener->on_operation_output(content);
+            }
         }
     }
 

--- a/src/domain/containers/freebsd/freebsd_container.cc
+++ b/src/domain/containers/freebsd/freebsd_container.cc
@@ -122,7 +122,7 @@ namespace domain::containers::freebsd
         auto pid = forkpty(&fd, NULL, NULL, &size);
         if (pid < 0)
         {
-            std::error_code(errno, std::system_category());
+            return std::error_code(errno, std::system_category());
         }
         else if (pid == 0)
         {

--- a/src/domain/containers/freebsd/freebsd_terminal.cc
+++ b/src/domain/containers/freebsd/freebsd_terminal.cc
@@ -1,0 +1,217 @@
+#include <domain/containers/freebsd/freebsd_terminal.h>
+#include <domain/containers/freebsd/freebsd_utils.h>
+#include <domain/containers/terminal_listener.h>
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
+#include <asio/read.hpp>
+#include <asio/write.hpp>
+#include <libutil.h>
+#include <sys/param.h>
+#include <sys/ioctl.h>
+#include <sys/jail.h>
+#include <spdlog/spdlog.h>
+
+namespace domain::containers::freebsd
+{
+    freebsd_terminal::freebsd_terminal(asio::io_context &context,
+                                       const std::string &identifier,
+                                       terminal_listener &listener) : context(context),
+                                                                      identifier(identifier),
+                                                                      listener(listener),
+                                                                      file_descriptor(-1),
+                                                                      process_identifier(-1),
+                                                                      buffer(WRITE_BUFFER_SIZE),
+                                                                      in(nullptr),
+                                                                      out(nullptr),
+                                                                      logger(spdlog::get("jpod")) {}
+    std::error_code freebsd_terminal::initialize()
+    {
+        disable_stdio_inheritance();
+        winsize size = {24, 80, 0, 0};
+        context.notify_fork(asio::io_context::fork_prepare);
+        int fd;
+        auto pid = forkpty(&fd, NULL, NULL, &size);
+        if (pid < 0)
+        {
+            return std::error_code(errno, std::system_category());
+        }
+        else if (pid == 0)
+        {
+            setsid();
+            if (int jail_id = jail_getid(identifier.c_str()); jail_id > 0)
+            {
+                if (jail_attach(jail_id) == -1 || chdir("/") == -1)
+                {
+                    listener.on_terminal_error(std::error_code(errno, std::system_category()));
+                    _exit(-errno);
+                }
+            }
+            context.notify_fork(asio::io_context::fork_child);
+            std::error_code error;
+            if (auto results = fetch_user_details("", error); error)
+            {
+                logger->error("insecure mode in effect error: {}", error.message());
+            }
+            else if (!setup_environment(*results))
+            {
+                logger->error("was not able to set up secure mode");
+            }
+            if (auto target_shell = getenv("SHELL"); target_shell != NULL)
+            {
+                if (auto err = execlp(target_shell, target_shell, "-i", NULL); err < 0)
+                {
+                    perror("execlp failed");
+                    listener.on_terminal_error(std::error_code(errno, std::system_category()));
+                    _exit(-errno);
+                }
+            }
+        }
+
+        // set the file descriptor non blocking
+        if (int flags = fcntl(fd, F_GETFL); flags != -1)
+        {
+            if (int ret = fcntl(fd, F_SETFD, flags | O_NONBLOCK); ret == -1)
+            {
+                clean();
+                return std::error_code(errno, std::system_category());
+            }
+            if (!close_on_exec(fd))
+            {
+                clean();
+            }
+            if (!setup_pipe(fd))
+            {
+                clean();
+                return std::error_code(errno, std::system_category());
+            }
+            this->file_descriptor = fd;
+            this->process_identifier = pid;
+            return std::error_code{};
+        }
+        clean();
+        return std::error_code(errno, std::system_category());
+    }
+
+    void freebsd_terminal::start()
+    {
+
+        asio::post([this]()
+                   { process_wait(process_identifier); });
+        asio::post([this]()
+                   { this->in->async_wait(
+                         asio::posix::stream_descriptor::wait_read,
+                         [this](const std::error_code &error)
+                         {
+                             if (!error)
+                             {
+                                 this->listener.on_terminal_initialized();
+                                 read_from_shell();
+                             }
+                             else
+                             {
+                                 listener.on_terminal_error(error);
+                             }
+                         }); });
+    }
+    void freebsd_terminal::resize(uint32_t columns, uint32_t rows)
+    {
+        struct winsize size;
+        size.ws_col = (unsigned short)columns;
+        size.ws_row = (unsigned short)rows;
+        size.ws_xpixel = 0;
+        size.ws_ypixel = 0;
+        if (ioctl(file_descriptor, TIOCSWINSZ, &size) < 0)
+        {
+            listener.on_terminal_error(std::error_code(errno, std::system_category()));
+        }
+    }
+    void freebsd_terminal::write(const std::vector<uint8_t> &content)
+    {
+        out->async_write_some(
+            asio::buffer(std::string(content.begin(), content.end())),
+            [this](const std::error_code &err, std::size_t bytes_transferred)
+            {
+                if (!err)
+                {
+                    this->logger->info("written to terminal");
+                }
+                else
+                {
+                    listener.on_terminal_error(err);
+                }
+            });
+    }
+    bool freebsd_terminal::setup_pipe(int fd)
+    {
+        if (auto fd_in_dup = ::dup(fd); fd_in_dup <= 0)
+        {
+            return false;
+        }
+        else if (auto fd_out_dup = ::dup(fd); fd_out_dup <= 0)
+        {
+            return false;
+        }
+        else
+        {
+            in = std::make_unique<asio::posix::stream_descriptor>(context, fd_in_dup);
+            out = std::make_unique<asio::posix::stream_descriptor>(context, fd_out_dup);
+        }
+        return true;
+    }
+    void freebsd_terminal::wait_to_read_from_shell()
+    {
+        this->in->async_wait(
+            asio::posix::stream_descriptor::wait_read,
+            [this](const std::error_code &error)
+            {
+                if (!error)
+                {
+                    this->read_from_shell();
+                }
+                else if (error != asio::error::eof)
+                {
+                    this->listener.on_terminal_error(error);
+                }
+            });
+    }
+    void freebsd_terminal::read_from_shell()
+    {
+        in->async_read_some(
+            asio::buffer(buffer),
+            [this](const std::error_code &error, std::size_t bytes_transferred)
+            {
+                if (!error)
+                {
+                    if (bytes_transferred > 0)
+                    {
+                        this->listener.on_terminal_data_received(buffer);
+                        this->in->async_wait(
+                            asio::posix::stream_descriptor::wait_read,
+                            [this](const std::error_code &err)
+                            {
+                                this->wait_to_read_from_shell();
+                            });
+                    }
+                }
+                else
+                {
+                    this->listener.on_terminal_error(error);
+                }
+            });
+    }
+    void freebsd_terminal::clean()
+    {
+        if (file_descriptor > 0 && process_identifier > 0)
+        {
+            close(file_descriptor);
+            waitpid(process_identifier, nullptr, 0);
+        }
+    }
+    freebsd_terminal::~freebsd_terminal()
+    {
+        clean();
+        buffer.clear();
+        in.reset();
+        out.reset();
+    }
+}

--- a/src/domain/containers/logging_handler.cc
+++ b/src/domain/containers/logging_handler.cc
@@ -12,13 +12,41 @@ namespace domain::containers
         std::shared_ptr<runtime> runtime_ptr) : command_handler(connection),
                                                 repository(repository),
                                                 runtime_ptr(runtime_ptr),
+                                                container_ptr(nullptr),
                                                 logger(spdlog::get("jpod"))
     {
     }
 
     void logging_handler::on_order_received(const std::vector<uint8_t> &payload)
     {
-        // auto order = unpack_container_termed_order(payload);
+        auto order = unpack_container_term_order(payload);
+        if (auto result = repository->first_identifier_match(order.term); !result)
+        {
+            // TODO: have to come up with custom errors for containers
+            send_error(std::make_error_code(std::errc::no_such_process));
+        }
+        else if (container_ptr = runtime_ptr->fetch_container(*result); !container_ptr)
+        {
+            // TODO: have to come up with custom errors for containers
+            send_error(std::make_error_code(std::errc::no_such_process));
+        }
+        else
+        {
+            container_ptr->register_listener(shared_from_this());
+        }
+    }
+    void logging_handler::on_operation_initialization()
+    {
+    }
+    void logging_handler::on_operation_output(const std::vector<uint8_t> &content)
+    {
+    }
+    void logging_handler::on_operation_failure(const std::error_code &error)
+    {
+    }
+    listener_category logging_handler::type()
+    {
+        return listener_category::observer;
     }
     void logging_handler::on_connection_closed(const std::error_code &error)
     {

--- a/src/domain/containers/logging_handler.cc
+++ b/src/domain/containers/logging_handler.cc
@@ -1,0 +1,29 @@
+#include <domain/containers/logging_handler.h>
+#include <domain/containers/repository.h>
+#include <domain/containers/runtime.h>
+#include <domain/containers/orders.h>
+#include <spdlog/spdlog.h>
+
+namespace domain::containers
+{
+    logging_handler::logging_handler(
+        core::connections::connection &connection,
+        std::shared_ptr<container_repository> repository,
+        std::shared_ptr<runtime> runtime_ptr) : command_handler(connection),
+                                                repository(repository),
+                                                runtime_ptr(runtime_ptr),
+                                                logger(spdlog::get("jpod"))
+    {
+    }
+
+    void logging_handler::on_order_received(const std::vector<uint8_t> &payload)
+    {
+        // auto order = unpack_container_termed_order(payload);
+    }
+    void logging_handler::on_connection_closed(const std::error_code &error)
+    {
+    }
+    logging_handler::~logging_handler()
+    {
+    }
+}

--- a/src/domain/containers/logging_handler.cc
+++ b/src/domain/containers/logging_handler.cc
@@ -37,12 +37,15 @@ namespace domain::containers
     }
     void logging_handler::on_operation_initialization()
     {
+        send_success("logging session started");
     }
     void logging_handler::on_operation_output(const std::vector<uint8_t> &content)
     {
+        send_frame(content);
     }
     void logging_handler::on_operation_failure(const std::error_code &error)
     {
+        send_error(error);
     }
     listener_category logging_handler::type()
     {

--- a/src/domain/containers/runtime.cc
+++ b/src/domain/containers/runtime.cc
@@ -54,6 +54,10 @@ namespace domain::containers
             monitors.erase(pos);
         }
     }
+    std::shared_ptr<container> runtime::fetch_container(const std::string &identifier)
+    {
+        return containers.at(identifier);
+    }
     runtime::~runtime()
     {
         containers.clear();

--- a/src/domain/containers/shell_handler.cc
+++ b/src/domain/containers/shell_handler.cc
@@ -33,7 +33,14 @@ namespace domain::containers
             else
             {
                 terminal = provider(*result, *this);
-                terminal->start();
+                if (auto error = terminal->initialize(); error)
+                {
+                    send_error(error);
+                }
+                else
+                {
+                    terminal->start();
+                }
             }
         }
         case shell::terminal_size:

--- a/src/domain/containers/shell_handler.cc
+++ b/src/domain/containers/shell_handler.cc
@@ -1,0 +1,81 @@
+#include <domain/containers/shell_handler.h>
+#include <domain/containers/virtual_terminal.h>
+#include <domain/containers/repository.h>
+#include <domain/containers/orders.h>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/split.hpp>
+#include <spdlog/spdlog.h>
+
+namespace domain::containers
+{
+    shell_handler::shell_handler(
+        core::connections::connection &connection,
+        std::shared_ptr<container_repository> repository,
+        virtual_terminal_provider provider) : command_handler(connection),
+                                              provider(std::move(provider)),
+                                              repository(repository),
+                                              logger(spdlog::get("jpod"))
+    {
+    }
+
+    void shell_handler::on_order_received(const std::vector<uint8_t> &payload)
+    {
+        auto order = unpack_container_shell_order(payload);
+        switch (order.type)
+        {
+        case shell::start_session:
+        {
+            if (auto result = repository->first_identifier_match(std::string(order.data.begin(), order.data.end())); !result)
+            {
+                // TODO: have to come up with custom errors for containers
+                send_error(std::make_error_code(std::errc::no_such_process));
+            }
+            else
+            {
+                terminal = provider(*result, *this);
+                terminal->start();
+            }
+        }
+        case shell::terminal_size:
+        {
+            auto value = std::string(order.data.begin(), order.data.end());
+            auto parts = value | ranges::view::split(':') | ranges::to<std::vector<std::string>>();
+            auto columns = std::stoi(parts.at(0));
+            auto rows = std::stoi(parts.at(1));
+            terminal->resize(columns, rows);
+            send_success("terminal session resized");
+        }
+        case shell::terminal_feed:
+        {
+            terminal->write(order.data);
+            break;
+        }
+        }
+    }
+    void shell_handler::on_terminal_initialized()
+    {
+        send_success("terminal session created");
+    }
+    void shell_handler::on_terminal_data_received(const std::vector<uint8_t> &content)
+    {
+        send_frame(content);
+    }
+    void shell_handler::on_terminal_error(const std::error_code &error)
+    {
+        send_error(error);
+    }
+    void shell_handler::on_connection_closed(const std::error_code &error)
+    {
+        if (error)
+        {
+            logger->error("client connection: {}", error.message());
+        }
+    }
+    shell_handler::~shell_handler()
+    {
+        if (terminal)
+        {
+            terminal.reset();
+        }
+    }
+}

--- a/src/domain/containers/sql_repository.cc
+++ b/src/domain/containers/sql_repository.cc
@@ -108,6 +108,27 @@ namespace domain::containers
             return details;
         }
     }
+
+    std::optional<std::string> sql_container_repository::first_identifier_match(const std::string &query)
+    {
+        std::string sql("SELECT "
+                        "c.identifier "
+                        "FROM container_tb AS c "
+                        "WHERE c.identifier LIKE ? "
+                        "OR c.name LIKE ? LIMIT 1");
+        auto connection = data_source.connection();
+        auto statement = connection->statement(sql);
+        statement.bind(0, query);
+        statement.bind(1, query);
+        if (auto result = statement.execute_query(); !result.has_next())
+        {
+            return std::nullopt;
+        }
+        else
+        {
+            return result.fetch<std::string>("identifier");
+        }
+    }
     std::error_code sql_container_repository::save(const container_properties &properties)
     {
         std::string sql("INSERT INTO container_tb(identifier, name, internals, image_id) "

--- a/src/domain/containers/start_handler.cc
+++ b/src/domain/containers/start_handler.cc
@@ -22,7 +22,7 @@ namespace domain::containers
 
     void start_handler::on_order_received(const std::vector<uint8_t> &payload)
     {
-        auto order = unpack_container_start_order(payload);
+        auto order = unpack_container_term_order(payload);
         // create the operation details from querying the database
         if (auto result = repository->first_match(order.term); !result.has_value())
         {


### PR DESCRIPTION
Added handlers to handle shell and logging operations coming from the client.

During the shell access process, information to through the same payload can be used to 

- Search and start the virtual terminal session
- Resize the virtual terminal (to the actual terminal on the host client)
- Handle user input coming from the client

The logs being emitted by the running process are collected by the `logging-handler` implementation of `container-listener` 

NB: 
- The virtual terminals will be platform specific with the first variation being for `FreeBSD` .
- The terminal output will be returned as a single frame from the `pseudo` terminal implementation.


