### PR TITLE
- added specific container errors creation

### DIFF
--- a/include/bootstrap.h
+++ b/include/bootstrap.h
@@ -78,9 +78,11 @@ public:
     void stop();
 
 private:
-    void setup_handlers();
+    
 
 private:
+    static asio::ssl::context context_provider(setting_properties& settings);
+    void setup_handlers();
     std::unique_ptr<domain::containers::virtual_terminal> create_virtual_terminal(
         domain::containers::terminal_properties properties,
         domain::containers::terminal_listener &listener);

--- a/include/bootstrap.h
+++ b/include/bootstrap.h
@@ -81,7 +81,7 @@ private:
     
 
 private:
-    static asio::ssl::context context_provider(setting_properties& settings);
+    static asio::ssl::context context_provider();
     void setup_handlers();
     std::unique_ptr<domain::containers::virtual_terminal> create_virtual_terminal(
         domain::containers::terminal_properties properties,
@@ -93,7 +93,6 @@ private:
 
 private:
     asio::io_context &context;
-    asio::ssl::context ssl_ctx;
     std::shared_ptr<command_handler_registry> registry;
     std::unique_ptr<connection_acceptor> acceptor;
     std::unique_ptr<core::sql::pool::data_source> data_source;

--- a/include/core/archives/errors.h
+++ b/include/core/archives/errors.h
@@ -9,13 +9,13 @@
 namespace core::archives
 {
     inline std::map<int, std::string> compression_error_map =
-        {
+    {
             {ARCHIVE_EOF, "Found end of archive"},
             {ARCHIVE_RETRY, "Retry might succeed"},
             {ARCHIVE_WARN, "Partial Success"},
             {ARCHIVE_FAILED, "Current operation cannot complete"},
             {ARCHIVE_FATAL, "No more operations are possible"}
-        };
+    };
     struct compression_failure_category : public std::error_category
     {
         compression_failure_category() {}

--- a/include/core/archives/helper.h
+++ b/include/core/archives/helper.h
@@ -14,6 +14,8 @@ namespace core::archives
 
     tl::expected<archive_ptr, std::error_code> initialize_reader(fs::path archive_path);
     tl::expected<archive_ptr, std::error_code> initialize_writer();
+    std::error_code copy_entry(struct archive *in, struct archive *out);
+    std::error_code copy_to_destination(archive_ptr in, archive_ptr out, fs::path& destination);
 }
 
 #endif //__DAEMON_CORE_ARCHIVES_HELPER__

--- a/include/core/archives/helper.h
+++ b/include/core/archives/helper.h
@@ -12,7 +12,7 @@ using archive_ptr = std::shared_ptr<archive>;
 namespace core::archives
 {
 
-    tl::expected<archive_ptr, std::error_code> initialize_reader(fs::path archive_path);
+    tl::expected<archive_ptr, std::error_code> initialize_reader(const fs::path& archive_path);
     tl::expected<archive_ptr, std::error_code> initialize_writer();
     std::error_code copy_entry(struct archive *in, struct archive *out);
     std::error_code copy_to_destination(archive_ptr in, archive_ptr out, fs::path& destination);

--- a/include/core/http/async_client.h
+++ b/include/core/http/async_client.h
@@ -1,0 +1,102 @@
+#ifndef __DAEMON_CORE_HTTP_ASYNC_CLIENT__
+#define __DAEMON_CORE_HTTP_ASYNC_CLIENT__
+
+#include <core/http/response.h>
+#include <asio/streambuf.hpp>
+#include <system_error>
+#include <functional>
+#include <llhttp.h>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <map>
+
+namespace spdlog
+{
+    class logger;
+};
+
+namespace core::http::internal
+{
+    class uri;
+};
+
+namespace core::http
+{
+    const std::size_t BUFFER_SIZE = 1024 * 6;
+    const uint16_t DEFAULT_RETRIES = 10;
+    struct request_details
+    {
+        std::string path;
+        std::map<std::string, std::string> headers;
+        std::string content_type;
+        std::vector<uint8_t> content;
+    };
+
+    struct http_session;
+    struct request;
+
+    using response_callback = std::function<void(const std::error_code &, const response &)>;
+    using session_provider = std::function<std::shared_ptr<http_session>(const std::string &scheme, const std::string &host)>;
+    using http_headers = std::map<std::string, std::string>;
+
+    struct connection_session
+    {
+        std::string id;
+        std::string method;
+        std::map<std::string, std::string> headers;
+        std::vector<uint8_t> request;
+        response_callback callback;
+        response initial_response;
+        uint16_t retries;
+        bool follow;
+        std::vector<uint8_t> raw;
+    };
+
+    class async_client
+    {
+    public:
+        explicit async_client(session_provider provider, uint16_t retries = DEFAULT_RETRIES);
+        virtual ~async_client();
+        void post(const request_details &details, response_callback callback);
+        void put(const request_details &details, response_callback callback);
+        void get(const std::string &path,
+                 const http_headers &headers,
+                 response_callback callback,
+                 bool follow = true);
+        void remove(
+            const std::string &path,
+            const http_headers &headers,
+            response_callback callback);
+        void head(const std::string &path, const http_headers &headers, response_callback callback, bool follow = false);
+
+    private:
+        std::shared_ptr<http_session> connection(const internal::uri &uri);
+        std::shared_ptr<http_session> connection(const std::string &id);
+        void send_request(const request &req);
+        void handle_redirect(const std::string &location);
+        void retry_last_request();
+        void read_response_header();
+        void read_body(std::size_t bytes_left_over);
+        void read_body();
+        void read_next_chunk();
+        void parse_chunks();
+        void on_request_failure(const std::error_code &error);
+        void on_response_failure(const std::error_code &error);
+        static int on_message_begin(llhttp_t *parser);
+        static int on_body(llhttp_t *parser, char const *data, size_t length);
+        static int on_message_complete(llhttp_t *parser);
+
+    private:
+        session_provider provider;
+        uint16_t retries;
+        std::string current_host;
+        connection_session session;
+        llhttp_t http_parser;
+        llhttp_settings_t settings;
+        asio::streambuf buffer;
+        std::map<std::string, std::shared_ptr<http_session>> connections;
+        std::shared_ptr<spdlog::logger> logger;
+    };
+}
+#endif //__DAEMON_CORE_HTTP_ASYNC_CLIENT__

--- a/include/core/http/request.h
+++ b/include/core/http/request.h
@@ -1,0 +1,83 @@
+#ifndef __DAEMON_CORE_HTTP_REQUEST__
+#define __DAEMON_CORE_HTTP_REQUEST__
+
+#include <core/http/uri.h>
+#include <tl/expected.hpp>
+#include <fmt/format.h>
+#include <system_error>
+#include <vector>
+#include <string>
+
+using namespace tl;
+
+namespace core::http
+{
+    struct request
+    {
+        std::vector<uint8_t> content;
+        internal::uri url;
+    };
+
+    auto compose_request(
+        const std::string &path,
+        const http_headers &headers,
+        std::string method) -> expected<request, std::error_code>
+    {
+        std::error_code error{};
+        request r{};
+        if (r.url = internal::parse_url(path, error); error)
+        {
+            return tl::make_unexpected(error);
+        }
+        auto header_line = fmt::format("{} {} HTTP/1.1\r\n"
+                                       "Host: {}\r\n"
+                                       "User-Agent: jpod client\r\n",
+                                       method,
+                                       r.url.full_path(),
+                                       r.url.full_host());
+        std::for_each(headers.begin(), headers.end(), [&header_line](const auto &entry)
+                      { header_line += fmt::format("{}: {}\r\n", entry.first, entry.second); });
+        header_line += "\r\n";
+        r.content.reserve(header_line.size());
+        r.content.assign(header_line.begin(), header_line.end());
+        return r;
+    }
+
+    auto compose_request(
+        const request_details &details,
+        std::string method) -> expected<request, std::error_code>
+    {
+        std::error_code error{};
+        request r{};
+        if (r.url = internal::parse_url(details.path, error); error)
+        {
+            return tl::make_unexpected(error);
+        }
+        else
+        {
+            auto header_line = fmt::format("{} {} HTTP/1.1\r\n"
+                                           "Host: {}\r\n"
+                                           "User-Agent: jpod client\r\n"
+                                           "Content-Type: {}\r\n"
+                                           "Content-Length: {}\r\n",
+                                           method,
+                                           r.url.path,
+                                           r.url.full_host(),
+                                           details.content_type,
+                                           details.content.size());
+            auto headers = details.headers;
+            std::for_each(headers.begin(), headers.end(), [&header_line](const auto &entry)
+                          { header_line += fmt::format("{}: {}\r\n", entry.first, entry.second); });
+            header_line += "\r\n";
+            r.content.reserve(header_line.size() + details.content.size());
+            r.content.assign(header_line.begin(), header_line.end());
+            if (!details.content.empty())
+            {
+                r.content.insert(r.content.end(), details.content.begin(), details.content.end());
+            }
+            return r;
+        }
+    }
+}
+
+#endif // __DAEMON_CORE_HTTP_REQUEST__

--- a/include/core/http/secure_session.h
+++ b/include/core/http/secure_session.h
@@ -23,7 +23,7 @@ namespace core::http
     class secure_http_session : public http_session, public std::enable_shared_from_this<secure_http_session>
     {
     public:
-        explicit secure_http_session(asio::io_context &context, asio::ssl::context &ssl_ctx);
+        explicit secure_http_session(asio::io_context &context, asio::ssl::context ssl_ctx);
         virtual ~secure_http_session();
         void connect(const std::string &host, uint16_t port, initialization_callback callback) override;
         void reconnect(initialization_callback callback) override;
@@ -43,7 +43,7 @@ namespace core::http
 
     private:
         asio::ip::tcp::resolver resolver;
-        asio::ssl::context &ssl_ctx;
+        asio::ssl::context ssl_ctx;
         asio::steady_timer timer;
         std::string host;
         uint16_t port;

--- a/include/core/http/ssl_configuration.h
+++ b/include/core/http/ssl_configuration.h
@@ -15,7 +15,7 @@ namespace core::http
 
     inline asio::ssl::context create_context(const ssl_configuration &configuration)
     {
-        asio::ssl::context ctx(asio::ssl::context::sslv23_client);
+        asio::ssl::context ctx(asio::ssl::context::tls_client);
         ctx.set_options(asio::ssl::context::default_workarounds);
         if (!configuration.certificate_file.empty() && !configuration.private_key_file.empty())
         {

--- a/include/core/oci/oci_client.h
+++ b/include/core/oci/oci_client.h
@@ -15,10 +15,6 @@ namespace fs = std::filesystem;
 namespace asio
 {
     class io_context;
-    namespace ssl
-    {
-        class context;
-    };
 };
 
 namespace spdlog
@@ -29,7 +25,7 @@ namespace spdlog
 namespace core::http
 {
     class http_session;
-    class rest_client;
+    class async_client;
 };
 
 namespace core::oci
@@ -134,7 +130,7 @@ namespace core::oci
     private:
         asio::io_context &context;
         session_provider provider;
-        std::unique_ptr<core::http::rest_client> client;
+        std::unique_ptr<core::http::async_client> client;
         std::map<std::string, std::map<std::string, std::shared_ptr<layer_download_task>>> download_tasks;
         std::map<std::string, image_details> images;
         std::map<std::string, configuration_request> configuration_requests;

--- a/include/core/oci/payloads.h
+++ b/include/core/oci/payloads.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <chrono>
 #include <filesystem>
+#include <optional>
 
 namespace fs = std::filesystem;
 
@@ -16,6 +17,16 @@ namespace core::oci
         registry_token,
         none
     };
+    inline auto authorization_variant_from_str(const std::string &type) -> std::optional<authorization_variant>
+    {
+        if (type == "NONE")
+            return authorization_variant::none;
+        if(type == "TOKEN")
+            return authorization_variant::registry_token;
+        if(type == "BASIC_AUTH")
+            return authorization_variant::basic_auth;
+        return std::nullopt;
+    }
     struct registry_credentials
     {
         std::string name;

--- a/include/core/oci/payloads.h
+++ b/include/core/oci/payloads.h
@@ -52,6 +52,7 @@ namespace core::oci
         std::string feed;
         std::size_t total_layers;
         uint16_t progress;
+        bool complete;
     };
     struct registry_session
     {

--- a/include/domain/containers/creation_handler.h
+++ b/include/domain/containers/creation_handler.h
@@ -2,10 +2,11 @@
 #define __DAEMON_DOMAIN_CONTAINERS_CREATION_HANDLER__
 
 #include <core/commands/command_handler.h>
-#include <domain/images/payload.h>
+#include <tl/expected.hpp>
 #include <system_error>
 #include <filesystem>
 #include <memory>
+#include <map>
 
 namespace spdlog
 {
@@ -13,15 +14,26 @@ namespace spdlog
 };
 
 struct archive;
-struct archive_entry;
-using archive_ptr = std::unique_ptr<archive, std::function<void(archive *)>>;
+using archive_ptr = std::shared_ptr<archive>;
 namespace fs = std::filesystem;
 namespace domain::containers
 {
     class container_repository;
+    struct creation_state
+    {
+        fs::path image_folder;
+        fs::path container_folder;
+        std::string image_identifier;
+        std::string container_identifier;
+        std::string name;
+        std::string network_properties;
+        std::map<std::string, std::string> port_map;
+        std::map<std::string, std::string> env_vars;
+        std::shared_ptr<container_repository> store;
+    };
+    using creation_result = tl::expected<creation_state, std::error_code>;
     class creation_handler : public core::commands::command_handler
     {
-        const int BUFFER_SIZE = 10240;
 
     public:
         creation_handler(core::connections::connection &connection,
@@ -33,22 +45,19 @@ namespace domain::containers
         void on_connection_closed(const std::error_code &error) override;
 
     private:
-        fs::path generate_container_folder(const std::string &identifier, std::error_code &error);
-        fs::path fetch_image_archive(std::string &image_identifier, std::error_code &error);
-        std::error_code initialize_decompression(std::string &image_identifier);
-        std::error_code extract_filesystem();
-        std::error_code copy_entry(struct archive *in, struct archive *out);
+        static creation_result initialize_creation(
+            std::string identifier,
+            std::shared_ptr<container_repository> store,
+            const fs::path &images_folder,
+            const fs::path &containers_folder,
+            const std::vector<uint8_t> &payload);
+        static creation_result extract_layers(creation_state state);
+        static tl::expected<std::string, std::error_code> register_container(creation_state state);
 
     private:
-        std::string identifier;
         const fs::path &containers_folder;
         const fs::path &images_folder;
-        fs::path container_directory;
         std::shared_ptr<container_repository> repository;
-        archive_ptr input;
-        archive_ptr output;
-        domain::images::progress_frame frame;
-        std::shared_ptr<spdlog::logger> logger;
     };
 }
 #endif // __DAEMON_DOMAIN_CONTAINERS_CREATION_HANDLER__

--- a/include/domain/containers/errors.h
+++ b/include/domain/containers/errors.h
@@ -1,0 +1,60 @@
+#ifndef __DAEMON_DOMAIN_CONTAINERS_ERRORS__
+#define __DAEMON_DOMAIN_CONTAINERS_ERRORS__
+
+#include <string>
+#include <map>
+
+namespace domain::containers
+{
+    enum class container_error
+    {
+        exists,
+        unknown_image,
+        extraction_failed,
+        not_found,
+        busy,
+        invalid_image
+    };
+    inline std::map<container_error, std::string> container_error_map =
+    {
+            {container_error::exists, "a container with the specified identifier already exists"},
+            {container_error::unknown_image, "the image specified to create the container does not exist"},
+            {container_error::extraction_failed, "image extraction failed during container creations"},
+            {container_error::not_found, "no matching container was found matching"},
+            {container_error::busy, "the specified container is busy at the moment"},
+            {container_error::invalid_image, "invalid image specified, please re-check the repository and tag"}
+    };
+    struct container_failure_category : public std::error_category
+    {
+        container_failure_category() {}
+        virtual ~container_failure_category() = default;
+        container_failure_category(const container_failure_category &) = delete;
+        const char *name() const noexcept override
+        {
+            return "container failures";
+        }
+
+        std::string message(int ec) const override
+        {
+            static const std::string unknown_error_code("unknown container failure");
+            if (auto pos = container_error_map.find(static_cast<container_error>(ec)); pos != container_error_map.end())
+            {
+                return pos->second;
+            }
+            return unknown_error_code;
+        }
+    };
+
+    inline const container_failure_category &__container_failure_category()
+    {
+        static container_failure_category fc;
+        return fc;
+    }
+
+    inline const std::error_code make_container_failure(container_error ec) noexcept
+    {
+
+        return std::error_code{static_cast<int>(ec), __container_failure_category()};
+    };
+}
+#endif // __DAEMON_DOMAIN_CONTAINERS_ERRORS__

--- a/include/domain/containers/repository.h
+++ b/include/domain/containers/repository.h
@@ -10,7 +10,8 @@ namespace domain::containers
     class container_repository
     {
     public:
-        virtual std::optional<domain::images::image_details> fetch_image_details(const std::string &registry, const std::string &name, const std::string &tag) = 0;
+        virtual std::optional<std::string> fetch_image_identifier(const std::string &registry, const std::string &name, const std::string &tag) = 0;
+        virtual std::optional<domain::images::image_details> fetch_image_details(const std::string& identifier) = 0;
         virtual std::optional<container_details> fetch(const std::string &identifier) = 0;
         virtual std::optional<container_details> first_match(const std::string &query) = 0;
         virtual std::optional<std::string> first_identifier_match(const std::string &query) = 0;

--- a/include/domain/containers/sql_repository.h
+++ b/include/domain/containers/sql_repository.h
@@ -15,7 +15,8 @@ namespace domain::containers
     public:
         sql_container_repository(core::sql::pool::data_source &data_source);
         virtual ~sql_container_repository();
-        std::optional<domain::images::image_details> fetch_image_details(const std::string &registry, const std::string &name, const std::string &tag) override;
+        std::optional<std::string> fetch_image_identifier(const std::string &registry, const std::string &name, const std::string &tag) override;
+        std::optional<domain::images::image_details> fetch_image_details(const std::string& identifier) override;
         std::optional<container_details> fetch(const std::string &identifier) override;
         std::optional<container_details> first_match(const std::string &query) override;
         std::optional<std::string> first_identifier_match(const std::string &query) override;

--- a/include/domain/images/errors.h
+++ b/include/domain/images/errors.h
@@ -5,34 +5,20 @@
 #include <map>
 #include <string>
 
-namespace domain::images::instructions
+namespace domain::images
 {
     enum class error_code
     {
-        file_not_found,
-        no_work_directory,
-        directory_not_found,
-        invalid_origin,
-        invalid_destination,
-        invalid_copy_instruction,
-        no_registry_entries_found,
-        no_matching_image_found,
-        no_registry_access,
-        invalid_order_issued,
-        no_mount_points_present
+        already_exists,
+        invalid_order,
+        unknown_image,
+        unknown_registry
     };
     const inline std::map<error_code, std::string> error_map{
-        {error_code::file_not_found, "file not found"},
-        {error_code::no_work_directory, "no work directory"},
-        {error_code::directory_not_found, "directory not found"},
-        {error_code::invalid_origin, "invalid origin"},
-        {error_code::invalid_destination, "invalid destination"},
-        {error_code::invalid_copy_instruction, "invalid copy instruction"},
-        {error_code::no_registry_entries_found, "no registries found"},
-        {error_code::no_matching_image_found, "no matching image found"},
-        {error_code::no_registry_access, "not authorized to access registry"},
-        {error_code::invalid_order_issued, "invalid order issued"},
-        {error_code::no_mount_points_present, "no mount points present for this file system"}};
+        {error_code::already_exists, "the specified image already exists"},
+        {error_code::invalid_order, "invalid image order"},
+        {error_code::unknown_image, "the image specified is unknown"},
+        {error_code::unknown_registry, "unknown registry specified"}};
 
     struct image_failure_category : public std::error_category
     {
@@ -41,7 +27,7 @@ namespace domain::images::instructions
         image_failure_category(const image_failure_category &) = delete;
         const char *name() const noexcept override
         {
-            return "image instruction failures";
+            return "image failures";
         }
 
         std::string message(int ec) const override

--- a/include/domain/images/helpers.h
+++ b/include/domain/images/helpers.h
@@ -3,15 +3,28 @@
 
 #include <string>
 #include <optional>
+#include <regex>
+#include <algorithm>
 
 namespace domain::images::instructions
 {
+    const std::regex DOMAIN_PATTERN("^(?!-)[A-Za-z0-9-]+([\\-\\.]{1}[a-z0-9]+)*\\.[A-Za-z]{2,6}$");
     struct image_registry_query
     {
         std::string registry;
         std::string repository;
         std::string tag;
     };
+
+    inline auto has_domain(const std::string &str) -> bool
+    {
+        if (auto pos = str.find_first_of('/'); pos != std::string::npos)
+        {
+            auto target = str.substr(0, pos);
+            return std::regex_match(target, DOMAIN_PATTERN);
+        }
+        return false;
+    }
 
     inline auto resolve_tagged_image_details(const std::string &tagged_image) -> std::optional<image_registry_query>
     {
@@ -21,26 +34,28 @@ namespace domain::images::instructions
         }
         image_registry_query query{};
         std::string tagged_name = "";
-        if (tagged_image.find_last_of("/") == std::string::npos)
+        bool is_official = false;
+        if (auto count = std::count(tagged_image.begin(), tagged_image.end(), '/'); count == 0 || !has_domain(tagged_image))
         {
-            query.registry = "localhost";
+            query.registry = "index.docker.io";
             tagged_name = tagged_image;
+            is_official = count == 0 && query.registry == "index.docker.io";
         }
         else
         {
-            auto position = tagged_image.find_last_of("/");
+            auto position = tagged_image.find_first_of("/");
             query.registry = tagged_image.substr(0, position);
             tagged_name = tagged_image.substr(position + 1);
         }
 
         if (auto position = tagged_name.find_last_of(":"); position != std::string::npos)
         {
-            query.repository = tagged_name.substr(0, position);
+            query.repository = (is_official ? "library/" : "") + tagged_name.substr(0, position);
             query.tag = tagged_name.substr(position + 1);
         }
         else
         {
-            query.repository = tagged_name;
+            query.repository = (is_official ? "library/" : "") + tagged_name;
             query.tag = "latest";
         }
         return std::optional{query};

--- a/include/domain/images/import_handler.h
+++ b/include/domain/images/import_handler.h
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <memory>
 #include <map>
+#include <vector>
 #include <tl/expected.hpp>
 
 namespace spdlog
@@ -26,8 +27,8 @@ namespace domain::images
 
     struct import_state
     {
-        std::string manifest;
-        std::string index;
+        std::vector<uint8_t> manifest;
+        std::vector<uint8_t> index;
         std::string identifier;
         std::string registry;
         std::string repository;
@@ -37,7 +38,7 @@ namespace domain::images
         std::string variant;
         std::string version;
         fs::path image_folder;
-        archive_ptr in;
+        fs::path image_archive;
         std::map<std::string, fs::path> entries;
         std::shared_ptr<image_repository> store;
         std::map<std::string, std::string> env_vars;
@@ -46,6 +47,7 @@ namespace domain::images
         std::vector<std::string> volumes;
         std::vector<std::string> command;
         std::vector<std::string> entry_point;
+        std::shared_ptr<spdlog::logger> logger;
     };
 
     using import_result = tl::expected<import_state, std::error_code>;
@@ -73,7 +75,6 @@ namespace domain::images
     private:
         std::shared_ptr<image_repository> repository;
         fs::path &image_folder;
-        std::shared_ptr<spdlog::logger> logger;
     };
 }
 #endif // __DAEMON_DOMAIN_IMAGES_IMPORT_COMMAND_HANDLER__

--- a/include/domain/images/mappings.h
+++ b/include/domain/images/mappings.h
@@ -26,7 +26,8 @@ namespace domain::images
     struct registry_access_details
     {
         std::string uri;
-        std::string token;
+        std::string authorization_type;
+        std::string authorization_url;
     };
 
     struct mount_point

--- a/include/domain/images/payload.h
+++ b/include/domain/images/payload.h
@@ -188,6 +188,20 @@ namespace domain::images
         msgpack::unpack(result, reinterpret_cast<const char *>(content.data()), content.size());
         return result.get().as<import_order>();
     }
+
+    struct pull_order
+    {
+        std::string target;
+        std::string credentials;
+        MSGPACK_DEFINE(target, credentials)
+    };
+
+    inline pull_order unpack_pull_order(const std::vector<uint8_t> &content)
+    {
+        msgpack::object_handle result;
+        msgpack::unpack(result, reinterpret_cast<const char *>(content.data()), content.size());
+        return result.get().as<pull_order>();
+    }
 }
 MSGPACK_ADD_ENUM(domain::images::step_type);
 #endif // __DAEMON_DOMAIN_IMAGES_PAYLOADS__

--- a/include/domain/images/pull_handler.h
+++ b/include/domain/images/pull_handler.h
@@ -2,8 +2,10 @@
 #define __DAEMON_DOMAIN_IMAGES_PULL_COMMAND_HANDLER__
 
 #include <core/commands/command_handler.h>
+#include <domain/images/mappings.h>
 #include <functional>
 #include <filesystem>
+#include <optional>
 #include <memory>
 #include <map>
 
@@ -24,14 +26,13 @@ namespace domain::images
 {
     using oci_client_provider = std::function<std::unique_ptr<core::oci::oci_client>()>;
     class image_repository;
-    class registry_access_details;
     struct progress_frame;
     class pull_handler : public core::commands::command_handler
     {
     public:
         explicit pull_handler(
             core::connections::connection &connection,
-            std::shared_ptr<image_repository> repository,
+            std::shared_ptr<image_repository> store,
             oci_client_provider provider,
             const fs::path &image_folder);
         virtual ~pull_handler();
@@ -39,15 +40,21 @@ namespace domain::images
         void on_connection_closed(const std::error_code &error) override;
 
     private:
-        void fetch_oci_image(const registry_access_details &details, const std::string &repository, const std::string &tag);
+        void authorize_client();
+        void fetch_oci_image();
+        void on_authorization(const std::error_code& error);
         void on_image_download(const std::error_code &error, const progress_update &update, const image_properties &properties);
         std::error_code save_image_details(const std::string identifier, const image_properties &properties);
 
     private:
-        std::shared_ptr<image_repository> repository;
+        std::shared_ptr<image_repository> store;
         oci_client_provider provider;
-        const fs::path &image_folder;
+        const fs::path &image_folder; 
         std::unique_ptr<core::oci::oci_client> client;
+        std::optional<registry_access_details> access_details;
+        std::string credentials;
+        std::string repository;
+        std::string tag;
         std::unique_ptr<progress_frame> frame;
         std::map<std::string, uint16_t> layer_progress;
         std::shared_ptr<spdlog::logger> logger;

--- a/include/domain/images/pull_handler.h
+++ b/include/domain/images/pull_handler.h
@@ -1,0 +1,57 @@
+#ifndef __DAEMON_DOMAIN_IMAGES_PULL_COMMAND_HANDLER__
+#define __DAEMON_DOMAIN_IMAGES_PULL_COMMAND_HANDLER__
+
+#include <core/commands/command_handler.h>
+#include <functional>
+#include <filesystem>
+#include <memory>
+#include <map>
+
+namespace spdlog
+{
+    class logger;
+};
+
+namespace core::oci
+{
+    class oci_client;
+    struct image_properties;
+    struct progress_update;
+};
+namespace fs = std::filesystem;
+using namespace core::oci;
+namespace domain::images
+{
+    using oci_client_provider = std::function<std::unique_ptr<core::oci::oci_client>()>;
+    class image_repository;
+    class registry_access_details;
+    struct progress_frame;
+    class pull_handler : public core::commands::command_handler
+    {
+    public:
+        explicit pull_handler(
+            core::connections::connection &connection,
+            std::shared_ptr<image_repository> repository,
+            oci_client_provider provider,
+            const fs::path &image_folder);
+        virtual ~pull_handler();
+        void on_order_received(const std::vector<uint8_t> &payload) override;
+        void on_connection_closed(const std::error_code &error) override;
+
+    private:
+        void fetch_oci_image(const registry_access_details &details, const std::string &repository, const std::string &tag);
+        void on_image_download(const std::error_code &error, const progress_update &update, const image_properties &properties);
+        std::error_code save_image_details(const std::string identifier, const image_properties &properties);
+
+    private:
+        std::shared_ptr<image_repository> repository;
+        oci_client_provider provider;
+        const fs::path &image_folder;
+        std::unique_ptr<core::oci::oci_client> client;
+        std::unique_ptr<progress_frame> frame;
+        std::map<std::string, uint16_t> layer_progress;
+        std::shared_ptr<spdlog::logger> logger;
+    };
+}
+
+#endif // __DAEMON_DOMAIN_IMAGES_PULL_COMMAND_HANDLER__

--- a/include/domain/images/pull_handler.h
+++ b/include/domain/images/pull_handler.h
@@ -56,7 +56,6 @@ namespace domain::images
         std::string repository;
         std::string tag;
         std::unique_ptr<progress_frame> frame;
-        std::map<std::string, uint16_t> layer_progress;
         std::shared_ptr<spdlog::logger> logger;
     };
 }

--- a/links.txt
+++ b/links.txt
@@ -3,3 +3,5 @@ https://www.lucavall.in/
 https://cesarvr.github.io/post/2018-05-22-create-containers/
 https://blog.lizzie.io/linux-containers-in-500-loc.html
 https://medium.com/@saschagrunert/demystifying-containers-part-i-kernel-space-2c53d6979504
+
+sudo valgrind -s --leak-check=full ./jcd

--- a/resources/migrations/initial-tables.sql
+++ b/resources/migrations/initial-tables.sql
@@ -22,7 +22,7 @@ CREATE TABLE
         registry_id INTEGER NOT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
         CONSTRAINT registry_fk FOREIGN KEY (registry_id) REFERENCES registry_tb (id) ON UPDATE RESTRICT ON DELETE RESTRICT,
-        CONSTRAINT image_unq UNIQUE (name, version, tag)
+        CONSTRAINT image_unq UNIQUE (repository, version, tag)
     );
 
 CREATE TABLE

--- a/resources/migrations/initial-tables.sql
+++ b/resources/migrations/initial-tables.sql
@@ -3,7 +3,8 @@ CREATE TABLE
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT NOT NULL,
         uri TEXT NOT NULL,
-        token TEXT,
+        authorization_type VARCHAR(10),
+        authorization_url TEXT,
         path TEXT,
         CONSTRAINT registry_unq UNIQUE (name)
     );

--- a/resources/migrations/local-registry.sql
+++ b/resources/migrations/local-registry.sql
@@ -1,1 +1,2 @@
 INSERT INTO registry_tb(name, uri, path) VALUES("localhost", "127.0.0.1", "localhost");
+INSERT INTO registry_tb(name, uri, path) VALUES("unknown", "127.0.0.1", "unknown");

--- a/resources/migrations/local-registry.sql
+++ b/resources/migrations/local-registry.sql
@@ -1,2 +1,2 @@
 INSERT INTO registry_tb(name, uri, path) VALUES("localhost", "127.0.0.1", "localhost");
-INSERT INTO registry_tb(name, uri, path) VALUES("unknown", "127.0.0.1", "unknown");
+INSERT INTO registry_tb(name, uri, path, authorization_type, authorization_url) VALUES("public.docker.hub","https://index.docker.io/v2", "index.docker.io", "NONE", "https://auth.docker.io/token?service=registry.docker.io");

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(jcd
                 domain/images/list_handler.cc
                 domain/images/build_handler.cc
                 domain/images/import_handler.cc
+                domain/images/pull_handler.cc
                 domain/images/removal_handler.cc
                 domain/images/instructions/download_instruction.cc
                 domain/images/instructions/copy_instruction.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(jcd
                 # core::http
                 core/http/secure_session.cc
                 core/http/insecure_session.cc
+                core/http/async_client.cc
                 core/http/rest_client.cc
                 core/http/file_transfer_client.cc
                 # core::commands

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -51,7 +51,7 @@ using namespace domain::containers;
 using namespace std::placeholders;
 
 bootstrap::bootstrap(asio::io_context &context, setting_properties settings) : context(context),
-                                                                               ssl_ctx(core::http::create_context({})),
+                                                                               ssl_ctx(context_provider(settings)),
                                                                                registry(std::make_shared<command_handler_registry>()),
                                                                                acceptor(std::make_unique<connection_acceptor>(context, settings.domain_socket, registry)),
                                                                                data_source(std::make_unique<core::sql::pool::data_source>(settings.database_path, settings.pool_size)),
@@ -65,6 +65,12 @@ bootstrap::bootstrap(asio::io_context &context, setting_properties settings) : c
                                                                                default_network_entry{"default", settings.bridge, settings.ip_v4_cidr, "local", "bridge"},
                                                                                logger(spdlog::get("jpod"))
 {
+}
+asio::ssl::context bootstrap::context_provider(setting_properties &settings)
+{
+  core::http::ssl_configuration configuration{};
+  configuration.verify = true;
+  return core::http::create_context(configuration);
 }
 void bootstrap::setup()
 {

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -15,6 +15,7 @@
 #include <domain/images/list_handler.h>
 #include <domain/images/build_handler.h>
 #include <domain/images/import_handler.h>
+#include <domain/images/pull_handler.h>
 #include <domain/images/sql_repository.h>
 
 // container headers
@@ -135,6 +136,13 @@ void bootstrap::setup_handlers()
       [this](connection &conn) -> std::shared_ptr<command_handler>
       {
         return std::make_shared<import_handler>(conn, images_folder, image_repository);
+      });
+  registry->add_handler(
+      operation_target::image,
+      request_operation::pull,
+      [this](connection &conn) -> std::shared_ptr<command_handler>
+      {
+        return std::make_shared<pull_handler>(conn, image_repository, std::bind(&bootstrap::oci_client_provider, this), images_folder);
       });
   // container handlers
   registry->add_handler(

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -51,7 +51,6 @@ using namespace domain::containers;
 using namespace std::placeholders;
 
 bootstrap::bootstrap(asio::io_context &context, setting_properties settings) : context(context),
-                                                                               ssl_ctx(context_provider(settings)),
                                                                                registry(std::make_shared<command_handler_registry>()),
                                                                                acceptor(std::make_unique<connection_acceptor>(context, settings.domain_socket, registry)),
                                                                                data_source(std::make_unique<core::sql::pool::data_source>(settings.database_path, settings.pool_size)),
@@ -66,7 +65,7 @@ bootstrap::bootstrap(asio::io_context &context, setting_properties settings) : c
                                                                                logger(spdlog::get("jpod"))
 {
 }
-asio::ssl::context bootstrap::context_provider(setting_properties &settings)
+asio::ssl::context bootstrap::context_provider()
 {
   core::http::ssl_configuration configuration{};
   configuration.verify = true;
@@ -235,7 +234,7 @@ std::shared_ptr<core::http::http_session> bootstrap::provider_http_session(const
 {
   if (scheme == "https")
   {
-    return std::make_shared<core::http::secure_http_session>(context, ssl_ctx);
+    return std::make_shared<core::http::secure_http_session>(context, context_provider());
   }
   else
   {

--- a/src/core/archives/helper.cc
+++ b/src/core/archives/helper.cc
@@ -4,7 +4,7 @@
 namespace core::archives
 {
     constexpr std::size_t BUFFER_SIZE = 10240;
-    tl::expected<archive_ptr, std::error_code> initialize_reader(fs::path archive_path)
+    tl::expected<archive_ptr, std::error_code> initialize_reader(const fs::path &archive_path)
     {
         archive_ptr arch = {
             archive_read_new(),
@@ -14,7 +14,7 @@ namespace core::archives
                 archive_read_free(instance);
             }};
         archive_read_support_filter_all(arch.get());
-        archive_read_support_format_raw(arch.get());
+        archive_read_support_format_tar(arch.get());
         if (auto ec = archive_read_open_filename(arch.get(), archive_path.c_str(), BUFFER_SIZE); ec != ARCHIVE_OK)
         {
             return tl::make_unexpected(make_compression_error_code(ec));

--- a/src/core/archives/helper.cc
+++ b/src/core/archives/helper.cc
@@ -21,7 +21,7 @@ namespace core::archives
         }
         return arch;
     }
-    
+
     tl::expected<archive_ptr, std::error_code> initialize_writer()
     {
         archive_ptr arch = {
@@ -38,5 +38,49 @@ namespace core::archives
         archive_write_disk_set_options(arch.get(), flags);
         archive_write_disk_set_standard_lookup(arch.get());
         return arch;
+    }
+
+    std::error_code copy_entry(struct archive *in, struct archive *out)
+    {
+        int ec;
+        const void *buffer;
+        std::size_t size;
+        la_int64_t offset;
+        while ((ec = archive_read_data_block(in, &buffer, &size, &offset)) == ARCHIVE_OK)
+        {
+            if (ec = archive_write_data_block(out, buffer, size, offset); ec != ARCHIVE_OK)
+            {
+                return make_compression_error_code(ec);
+            }
+        }
+        if (ec = archive_write_finish_entry(out); ec != ARCHIVE_OK)
+        {
+            return make_compression_error_code(ec);
+        }
+        return {};
+    }
+    std::error_code copy_to_destination(archive_ptr in, archive_ptr out, fs::path &destination)
+    {
+        archive_entry *entry;
+        while (archive_read_next_header(in.get(), &entry) == ARCHIVE_OK)
+        {
+            const char *entry_name = archive_entry_pathname(entry);
+            const mode_t type = archive_entry_filetype(entry);
+            fs::path full_path = destination / fs::path(std::string(entry_name));
+            archive_entry_set_pathname(entry, full_path.generic_string().c_str());
+            if (auto ec = archive_write_header(out.get(), entry); ec != ARCHIVE_OK)
+            {
+                return make_compression_error_code(ec);
+            }
+            else if (archive_entry_size(entry) > 0)
+            {
+                auto entry_size = archive_entry_size(entry);
+                if (auto error = copy_entry(in.get(), out.get()); error)
+                {
+                    return error;
+                }
+            }
+        }
+        return {};
     }
 }

--- a/src/core/http/async_client.cc
+++ b/src/core/http/async_client.cc
@@ -1,0 +1,462 @@
+#include <core/http/async_client.h>
+#include <core/http/session.h>
+#include <core/http/request.h>
+#include <spdlog/spdlog.h>
+
+namespace core::http
+{
+    async_client::async_client(session_provider provider, uint16_t retries) : provider(provider),
+                                                                              retries(retries),
+                                                                              session{},
+                                                                              settings{},
+                                                                              buffer(BUFFER_SIZE),
+                                                                              connections{},
+                                                                              logger(spdlog::get("jpod"))
+    {
+        /*Initialize user callbacks and settings */
+        llhttp_settings_init(&settings);
+        settings.on_message_begin = async_client::on_message_begin;
+        settings.on_message_complete = async_client::on_message_complete;
+        settings.on_body = async_client::on_body;
+        llhttp_init(&http_parser, HTTP_RESPONSE, &settings);
+        http_parser.data = this;
+        llhttp_set_lenient_optional_lf_after_cr(&http_parser, 1);
+    }
+    void async_client::post(const request_details &details, response_callback callback)
+    {
+        if (auto result = compose_request(details, "POST"); !result)
+        {
+            callback(result.error(), {});
+        }
+        else
+        {
+            session.follow = false;
+            session.method = "POST";
+            session.retries = 0;
+            session.initial_response = {};
+            session.callback = std::move(callback);
+            send_request(result.value());
+        }
+    }
+    void async_client::put(const request_details &details, response_callback callback)
+    {
+        if (auto result = compose_request(details, "PUT"); !result)
+        {
+            callback(result.error(), {});
+        }
+        else
+        {
+            session.follow = false;
+            session.method = "PUT";
+            session.retries = 0;
+            session.initial_response = {};
+            session.callback = std::move(callback);
+            send_request(result.value());
+        }
+    }
+    void async_client::get(const std::string &path,
+                           const http_headers &headers,
+                           response_callback callback,
+                           bool follow)
+    {
+        if (auto result = compose_request(path, headers, "GET"); !result)
+        {
+            callback(result.error(), {});
+        }
+        else
+        {
+            session.follow = follow;
+            session.method = "GET";
+            session.retries = 0;
+            session.initial_response = {};
+            session.headers.insert(headers.begin(), headers.end());
+            session.callback = std::move(callback);
+            send_request(result.value());
+        }
+    }
+    void async_client::remove(
+        const std::string &path,
+        const http_headers &headers,
+        response_callback callback)
+    {
+        if (auto result = compose_request(path, headers, "DELETE"); !result)
+        {
+            callback(result.error(), {});
+        }
+        else
+        {
+            session.follow = false;
+            session.method = "DELETE";
+            session.retries = 0;
+            session.initial_response = {};
+            session.callback = std::move(callback);
+            send_request(result.value());
+        }
+    }
+    void async_client::head(const std::string &path, const http_headers &headers, response_callback callback, bool follow)
+    {
+        if (auto result = compose_request(path, headers, "HEAD"); !result)
+        {
+            callback(result.error(), {});
+        }
+        else
+        {
+            session.follow = follow;
+            session.method = "HEAD";
+            session.retries = 0;
+            session.initial_response = {};
+            session.headers.insert(headers.begin(), headers.end());
+            session.callback = std::move(callback);
+            send_request(result.value());
+        }
+    }
+
+    std::shared_ptr<http_session> async_client::connection(const internal::uri &uri)
+    {
+
+        if (connections.find(uri.full_host()) == connections.end())
+        {
+            connections.try_emplace(uri.full_host(), provider(uri.scheme, uri.host));
+        }
+        return connections.at(uri.full_host());
+    }
+    std::shared_ptr<http_session> async_client::connection(const std::string &id)
+    {
+        return connections.at(id);
+    }
+    void async_client::send_request(const request &req)
+    {
+        session.request.assign(req.content.begin(), req.content.end());
+        session.id = req.url.full_host();
+        connection(req.url)->connect(
+            req.url.host,
+            req.url.port,
+            [this, req = std::move(req)](const std::error_code &error)
+            {
+                if (error)
+                {
+                    this->on_request_failure(error);
+                }
+                else
+                {
+                    connection(req.url)->async_write(
+                        session.request,
+                        [this](const std::error_code &err, std::size_t bytes_transferred)
+                        {
+                            if (err)
+                            {
+                                logger->error("content not transferred: {}", err.message());
+                                this->on_request_failure(err);
+                            }
+                            else
+                            {
+                                if (bytes_transferred > 0)
+                                {
+                                    logger->info("transferred : {} bytes", bytes_transferred);
+                                    this->read_response_header();
+                                }
+                            }
+                        });
+                }
+            });
+    }
+
+    void async_client::handle_redirect(const std::string &location)
+    {
+        std::error_code error{};
+        if (auto result = compose_request(location, session.headers, session.method); !result)
+        {
+            on_request_failure(result.error());
+        }
+        else
+        {
+            session.initial_response = {};
+            session.raw.clear();
+            session.retries = 0;
+            send_request(result.value());
+        }
+    }
+    void async_client::retry_last_request()
+    {
+        auto current_connection = connection(session.id);
+        session.initial_response = {};
+        current_connection->reconnect(
+            [this](const std::error_code &error)
+            {
+                if (error)
+                {
+                    on_response_failure(error);
+                }
+                else
+                {
+                    connection(session.id)->async_write(session.request, [this](const std::error_code &err, std::size_t bytes_transferred)
+                                                        {
+                            if (err)
+                            {
+                                logger->error("content not transferred: {}", err.message());
+                                this->on_request_failure(err);
+                            }
+                            else if (bytes_transferred > 0)
+                            {
+                                logger->info("transferred : {} bytes", bytes_transferred);
+                                this->read_response_header();
+                                
+                            } });
+                }
+            });
+    }
+    void async_client::read_response_header()
+    {
+        auto current_connection = connection(session.id);
+        current_connection->read_header(
+            this->buffer,
+            [this](std::error_code error, std::size_t bytes_transferred)
+            {
+                if (error)
+                {
+                    if (error == asio::error::eof && session.retries < retries)
+                    {
+                        retry_last_request();
+                    }
+                    else
+                    {
+                        this->on_response_failure(error);
+                    }
+                }
+                else if (bytes_transferred > 0)
+                {
+                    std::stringstream ss;
+                    ss << &this->buffer;
+                    std::string headers_contained = ss.str();
+                    if (auto headers_end = headers_contained.find("\r\n\r\n"); headers_end != std::string::npos)
+                    {
+                        std::string exact_header_content = headers_contained.substr(0, headers_end + 4);
+                        std::string remaining_content = headers_contained.substr(headers_end + 4);
+                        std::size_t remaining_bytes = headers_contained.substr(headers_end + 4).size();
+                        session.initial_response = parse_response(exact_header_content, error);
+                        if (error)
+                        {
+                            logger->error("parsing header content failed");
+                            this->on_response_failure(error);
+                        }
+                        else
+                        {
+                            if (session.initial_response.has_body())
+                            {
+                                auto part = ss.str();
+                                session.raw.assign(part.begin(), part.end());
+                                std::size_t content_length = session.initial_response.content_length();
+                                this->buffer.consume(bytes_transferred);
+                                this->read_body(remaining_bytes < content_length ? content_length - remaining_bytes : content_length);
+                            }
+                            else if (session.initial_response.is_closed())
+                            {
+                                this->buffer.consume(bytes_transferred);
+                                this->read_body();
+                            }
+                            else if (session.initial_response.is_chunked())
+                            {
+                                logger->info("is chunked");
+                                auto part = ss.str();
+                                session.raw.assign(part.begin(), part.end());
+                                buffer.consume(bytes_transferred);
+                                read_next_chunk();
+                            }
+                            else if (session.initial_response.is_redirect())
+                            {
+                                if (!session.follow)
+                                {
+                                    logger->info("not handling re-direct");
+                                    session.callback({}, session.initial_response);
+                                }
+                                else
+                                {
+                                    logger->info("been asked to re-direct");
+                                    buffer.consume(buffer.size());
+                                    connection(session.id)->delay([this](const std::error_code &error)
+                                                                  {
+                                            if (error)
+                                            {
+                                                on_request_failure(error);
+                                            }
+                                            else
+                                            {
+                                                logger->info("redirecting now");
+                                                handle_redirect(session.initial_response.location());
+                                            } });
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+    }
+    void async_client::read_body(std::size_t bytes_left_over)
+    {
+        auto current_connection = connection(session.id);
+        current_connection->read_exactly(
+            this->buffer,
+            bytes_left_over,
+            [this, bytes_left_over](const std::error_code &err, std::size_t bytes_transferred)
+            {
+                if (!err)
+                {
+                    if (bytes_transferred > 0)
+                    {
+                        std::istream stream(&this->buffer);
+                        std::vector<uint8_t> content(bytes_transferred);
+                        stream.read((char *)&content[0], bytes_transferred);
+                        session.raw.insert(session.raw.end(), content.begin(), content.end());
+                        buffer.consume(bytes_transferred);
+                        this->read_body(bytes_left_over - bytes_transferred);
+                    }
+                    else
+                    {
+                        buffer.consume(buffer.size());
+                        parse_chunks();
+                    }
+                }
+                else
+                {
+                    if (err == asio::error::eof)
+                    {
+                        parse_chunks();
+                    }
+                    else
+                    {
+                        this->on_request_failure(err);
+                    }
+                }
+            });
+    }
+    void async_client::read_body()
+    {
+        auto current_connection = connection(session.id);
+        current_connection->read(
+            this->buffer,
+            [this](const std::error_code &error, std::size_t bytes_transferred)
+            {
+                if (!error)
+                {
+                    if (bytes_transferred > 0)
+                    {
+                        std::istream stream(&this->buffer);
+                        std::vector<uint8_t> content(bytes_transferred);
+                        stream.read((char *)&content[0], bytes_transferred);
+                        session.raw.insert(session.raw.end(), content.begin(), content.end());
+                        buffer.consume(bytes_transferred);
+                        this->read_body();
+                    }
+                    else
+                    {
+                        parse_chunks();
+                    }
+                }
+                else
+                {
+                    if (error == asio::error::eof)
+                    {
+                        buffer.consume(buffer.size());
+                        parse_chunks();
+                    }
+                    else
+                    {
+                        this->on_request_failure(error);
+                    }
+                }
+            });
+    }
+    void async_client::read_next_chunk()
+    {
+        logger->info("reading next chunk");
+        auto current_connection = connection(session.id);
+        current_connection->read_until(
+            buffer,
+            "\r\n\r\n",
+            [this](const std::error_code &err, std::size_t bytes_transferred)
+            {
+                if (err)
+                {
+                    if (err == asio::error::eof)
+                    {
+                        parse_chunks();
+                        llhttp_reset(&http_parser);
+                    }
+                    else
+                    {
+                        this->on_request_failure(err);
+                    }
+                }
+                else if (bytes_transferred > 0)
+                {
+                    logger->info("got more bytes: {} as chunk", bytes_transferred);
+                    std::istream stream(&buffer);
+                    std::vector<uint8_t> content(bytes_transferred);
+                    stream.read((char *)&content[0], bytes_transferred);
+                    session.raw.insert(session.raw.end(), content.begin(), content.end());
+                    buffer.consume(bytes_transferred);
+                    read_next_chunk();
+                }
+            });
+    }
+    void async_client::parse_chunks()
+    {
+        std::string content(session.raw.begin(), session.raw.end());
+        if (auto result = llhttp_execute(&http_parser, content.c_str(), content.size()); result != HPE_OK)
+        {
+            logger->error("parser nxt-cnk error: ERR: {} REASON: {}", llhttp_errno_name(result), http_parser.reason);
+        }
+    }
+
+    void async_client::on_request_failure(const std::error_code &error)
+    {
+        session.callback(error, {});
+    }
+    void async_client::on_response_failure(const std::error_code &error)
+    {
+        session.callback(error, {});
+    }
+
+    int async_client::on_message_begin(llhttp_t *parser)
+    {
+        auto self = static_cast<async_client *>(parser->data);
+        self->logger->trace("begin body");
+        return 0;
+    }
+
+    int async_client::on_body(llhttp_t *parser, char const *data, size_t length)
+    {
+        auto self = static_cast<async_client *>(parser->data);
+        self->session.initial_response.data.reserve(length);
+        std::string content(data, length);
+        self->session.initial_response.data.insert(self->session.initial_response.data.end(), content.begin(), content.end());
+        return 0;
+    }
+
+    int async_client::on_message_complete(llhttp_t *parser)
+    {
+        auto self = static_cast<async_client *>(parser->data);
+        self->logger->info("completed");
+        self->buffer.consume(self->buffer.size());
+        self->session.callback({}, self->session.initial_response);
+        return 0;
+    }
+    async_client::~async_client()
+    {
+        logger->warn("clearing sessions");
+        if(!connections.empty())
+        {
+            connections.clear();
+        }
+        if(!session.initial_response.headers.empty())
+        {
+            logger->warn("nuking response headers");
+            session.initial_response.headers.clear();
+        }
+        if(!session.initial_response.data.empty())
+        {
+            logger->warn("nuking response data");
+            session.initial_response.data.clear();
+        }
+    }
+}

--- a/src/core/http/rest_client.cc
+++ b/src/core/http/rest_client.cc
@@ -7,7 +7,7 @@
 namespace core::http
 {
     rest_client::rest_client(session_provider provider) : provider(provider),
-                                                          buffer(5120),
+                                                          buffer(1024 * 6),
                                                           connection(nullptr),
                                                           http_parser{},
                                                           settings{},
@@ -364,7 +364,7 @@ namespace core::http
                                 {
                                     auto part = ss.str();
                                     raw_response.assign(part.begin(), part.end());
-                                    buffer.consume(buffer.size());
+                                    this->buffer.consume(bytes_transferred);
                                     read_next_chunk();
                                 }
                                 else if (session.initial_response.is_event_stream())

--- a/src/core/http/secure_session.cc
+++ b/src/core/http/secure_session.cc
@@ -83,7 +83,6 @@ namespace core::http
                                                 }
                                                 else
                                                 {
-                                                    logger->info("handshake successful for: {}", host);
                                                     this->host = host;
                                                     this->port = port;
                                                     this->verified = true;
@@ -116,7 +115,6 @@ namespace core::http
                                     {
                                         stream->lowest_layer().close();
                                     }
-                                    logger->info("closed old secure connection");  
                                     verified = false;
                                     timer.expires_from_now(asio::chrono::milliseconds(500));  
                                     timer.async_wait([this,cb=std::move(cb), _(shared_from_this())](const std::error_code& error){
@@ -135,7 +133,6 @@ namespace core::http
     }
     void secure_http_session::shutdown()
     {
-        logger->warn("dumping secure connection");
         if (stream)
         {
             std::error_code error{};
@@ -154,7 +151,6 @@ namespace core::http
 
             SSL_clear(stream->native_handle());
             stream.reset();
-            logger->info("dumped secure connection");
         }
     }
     bool secure_http_session::is_scheme_matched(const std::string &scheme)
@@ -243,7 +239,6 @@ namespace core::http
     */
     secure_http_session::~secure_http_session()
     {
-        logger->warn("dumping secure connection");
         if (stream)
         {
             std::error_code error{};
@@ -262,7 +257,6 @@ namespace core::http
 
             SSL_clear(stream->native_handle());
             stream.reset();
-            logger->warn("connection dumped");
         }
     }
 }

--- a/src/core/oci/layer_download_task.cc
+++ b/src/core/oci/layer_download_task.cc
@@ -23,8 +23,6 @@ namespace core::oci
         file_path = fs::path(this->details.folder / fs::path(fmt::format("layer_{0}.{1}", this->details.index, extension)))
                         .generic_string();
         client = std::make_unique<core::http::file_transfer_client>(context, this->details.provider);
-        logger->info("INDEX: {} URL: {}", this->details.index, this->details.layer_url);
-        logger->info("FILE PATH :{}", file_path);
     }
     bool layer_download_task::is_valid()
     {
@@ -50,7 +48,6 @@ namespace core::oci
     }
     std::size_t layer_download_task::write(const std::vector<uint8_t> &data)
     {
-        logger->info("writing {} bytes to file", data.size());
         std::ofstream file(file_path, std::ios::binary | std::ios::app);
         file.write(reinterpret_cast<const char *>(data.data()), data.size());
         file.close();
@@ -82,7 +79,6 @@ namespace core::oci
     void layer_download_task::abort()
     {
         // stop the client and remove the file
-        logger->warn("removing layer: {}", file_path);
         std::error_code error{};
         if(fs::remove(fs::path(file_path), error); error) 
         {

--- a/src/core/oci/oci_client.cc
+++ b/src/core/oci/oci_client.cc
@@ -1,7 +1,7 @@
 #include <core/oci/oci_client.h>
 #include <core/oci/layer_download_task.h>
 #include <core/oci/payloads.h>
-#include <core/http/rest_client.h>
+#include <core/http/async_client.h>
 #include <core/http/response.h>
 #include <core/http/session.h>
 #include <asio/ssl/error.hpp>
@@ -26,7 +26,7 @@ namespace core::oci
 {
     oci_client::oci_client(asio::io_context &context, session_provider provider) : context(context),
                                                                                    provider(provider),
-                                                                                   client(std::make_unique<core::http::rest_client>(provider)),
+                                                                                   client(std::make_unique<core::http::async_client>(provider)),
                                                                                    download_tasks{},
                                                                                    logger(spdlog::get("jpod"))
     {

--- a/src/core/oci/oci_client.cc
+++ b/src/core/oci/oci_client.cc
@@ -116,16 +116,18 @@ namespace core::oci
 
     void oci_client::on_download_complete(const std::string &image_digest, const std::string &layer_digest)
     {
-        logger->info("download complete");
+        auto details = images.at(image_digest);
+        progress_update update{};
+        update.progress = 100;
+        update.image_digest = image_digest;
+        update.layer_digest = layer_digest;
+        update.feed = "finished layer download";
+        update.stage = "image download";
+        update.total_layers = details.layers.size();
         auto tasks = download_tasks.at(image_digest);
         if (auto position = tasks.find(layer_digest); position != tasks.end())
         {
-            logger->warn("nuking old task");
             tasks.erase(position);
-        }
-        else
-        {
-            logger->error("old task not found");
         }
         start_sequence.pop_front();
         if (!start_sequence.empty())
@@ -134,8 +136,10 @@ namespace core::oci
             auto pending_tasks = download_tasks.at(target.first);
             auto task = pending_tasks.at(target.second);
             task->start();
+            update.complete = false;
+            details.callback({}, update, {});
         }
-        else if (tasks.empty())
+        else if (start_sequence.empty())
         {
             download_tasks.erase(download_tasks.find(image_digest));
             // persist the configuration and manifest
@@ -146,6 +150,8 @@ namespace core::oci
             std::ofstream configuration(image.destination / fs::path("config.json"), std::ios::out | std::ios::binary);
             manifest.write(reinterpret_cast<const char *>(image.configuration.data()), image.configuration.size());
             manifest.close();
+            update.complete = true;
+            details.callback({}, update, details.properties);
         }
     }
     void oci_client::on_download_update(const update_details &details)
@@ -154,10 +160,12 @@ namespace core::oci
         {
             auto &image = position->second;
             progress_update progress{};
+            progress.feed = "image layer downloading";
             progress.image_digest = details.image_digest;
             progress.layer_digest = details.layer_digest;
             progress.total_layers = image.layers.size();
             progress.progress = (details.current * 100) / details.total;
+            progress.complete = false;
             image.callback({}, progress, image.properties);
         }
     }
@@ -216,24 +224,26 @@ namespace core::oci
                     auto payload = json::parse(resp.data);
                     if (payload.contains("manifests"))
                     {
-                        logger->info("got image manifest index");
-                        logger->info("#### ARCH : {} #### OS : {}", req.architecture, req.operating_system);
+                        progress_update update{};
+                        update.stage = "resolving correct manifest";
+                        update.feed = std::string("got image manifest index");
+                        update.feed.append(fmt::format("#### ARCH : {} #### OS : {}\n", req.architecture, req.operating_system));
                         for (const auto &entry : payload["manifests"])
                         {
                             if (entry.contains("platform"))
                             {
                                 auto architecture = entry["platform"]["architecture"].template get<std::string>();
-                                logger->info("ARCH: {}", architecture);
+                                update.feed.append(fmt::format("ARCH: {}", architecture));
                                 auto operating_system = entry["platform"]["os"].template get<std::string>();
-                                logger->info("OPERATING SYSTEM: {}", operating_system);
+                                update.feed.append(fmt::format("OPERATING SYSTEM: {}", operating_system));
                                 if (entry["platform"].contains("variant"))
                                 {
                                     architecture = fmt::format("{}:{}", architecture, entry["platform"]["variant"].template get<std::string>());
-                                    logger->info("VARIATION OF ARCH: {}", architecture);
+                                    update.feed.append(fmt::format("VARIATION OF ARCH: {}", architecture));
                                 }
                                 if (req.operating_system == operating_system && req.architecture == architecture)
                                 {
-                                    logger->info("GOT A MATCH");
+                                    update.feed.append("GOT A MATCH");
                                     manifest_request request{};
                                     request.name = req.name;
                                     request.registry = req.registry;
@@ -242,6 +252,8 @@ namespace core::oci
                                     request.headers.try_emplace("Accept", entry["mediaType"].template get<std::string>());
                                     request.tag = entry["digest"].template get<std::string>();
                                     request.destination = req.destination;
+                                    update.feed.append("fetching manifest");
+                                    cb({}, update, {});
                                     fetch_manifest(request, std::move(cb));
                                     return;
                                 }
@@ -253,14 +265,16 @@ namespace core::oci
                     }
                     else if (payload.contains("config"))
                     {
-                        logger->info("got image manifest");
+                        progress_update update{};
+                        update.stage = "found image manifest";
                         // this means you are at the final image of interest, fetch layers
                         auto digest = payload["config"]["digest"].template get<std::string>();
+                        update.image_digest = digest;
+                        update.feed = std::string("found matching configuration identifier");
                         image_details details{};
                         details.tag = req.tag;
                         details.registry = req.registry;
                         details.repository = req.repository;
-
                         details.destination = req.destination;
 
                         for (const auto &layer_entry : payload["layers"])
@@ -289,6 +303,7 @@ namespace core::oci
                         conf_req.repository = fmt::format("{}", req.repository);
                         conf_req.token = fmt::format("{}", req.token);
                         configuration_requests.try_emplace(digest, std::move(conf_req));
+                        cb({}, update, {});
                         fetch_configuration(std::move(digest), std::move(cb));
                     }
                 }
@@ -305,7 +320,6 @@ namespace core::oci
         {
             auto request = pos->second;
             std::string path = fmt::format("{0}/{1}/blobs/{2}", request.registry, request.repository, digest);
-            logger->info("PATH: {}", path);
             std::map<std::string, std::string> headers;
             headers.try_emplace("Authorization", fmt::format("Bearer {}", request.token));
             headers.try_emplace("Connection", "Keep-Alive");
@@ -334,14 +348,7 @@ namespace core::oci
                     }
                     else
                     {
-                        logger->info("got image configuration");
                         add_configuration(digest, resp.data, std::move(cb));
-                        logger->info("parsed configuration");
-                        if (digest.empty())
-                        {
-                            logger->info("crap");
-                        }
-                        logger->info("using IMAGE DIGEST:{} to fetch layers", digest);
                         fetch_layers(std::move(digest));
                     }
                 });
@@ -352,19 +359,7 @@ namespace core::oci
     {
         auto payload = json::parse(data);
         image_properties properties{};
-        auto image = images.at(digest);
-
-        for (const auto &layer : image.layers)
-        {
-            properties.size += layer.size;
-        }
         properties.os = payload["os"].template get<std::string>();
-        properties.tag = image.tag;
-        properties.registry = image.registry;
-        properties.repository = image.repository;
-        properties.variant = image.variant;
-        properties.version = image.version;
-
         for (auto &[key, value] : payload["config"]["ExposedPorts"].items())
         {
             auto parts = key | views::split('/') | to<std::vector<std::string>>();
@@ -402,25 +397,39 @@ namespace core::oci
                 properties.layer_diffs.push_back(layer_id.template get<std::string>());
             }
         }
-        logger->info("inside configuration packaging");
+
         if (auto position = images.find(digest); position != images.end())
         {
-            logger->info("using digest to pack properties and callback");
             position->second.properties = std::move(properties);
+            position->second.properties.tag = position->second.tag;
+            position->second.properties.registry = position->second.registry;
+            position->second.properties.repository = position->second.repository;
+            position->second.properties.variant = position->second.variant;
+            position->second.properties.version = position->second.version;
+            for (const auto &layer : position->second.layers)
+            {
+                position->second.properties.size += layer.size;
+            }
             position->second.callback = std::move(callback);
-            image.configuration.assign(data.begin(), data.end());
+            position->second.configuration.assign(data.begin(), data.end());
         }
+        progress_update update{};
+        update.stage = "adding image configuration";
+        update.feed = "found image configuration details";
+        callback({}, update, {});
     }
 
     void oci_client::fetch_layers(std::string digest)
     {
-        logger->info("setting up download tasks");
+        progress_update update{};
+        update.stage = "download";
+        update.feed = std::string("setting up download tasks\n");
         auto &details = images.at(digest);
         auto request = configuration_requests.at(digest);
         std::map<std::string, std::shared_ptr<layer_download_task>> tasks{};
         download_tasks.try_emplace(digest, std::move(tasks));
         uint16_t index = 0;
-        //details.destination = details.destination / fs::path("sha256") / fs::path(digest.replace("sha256:", ""));
+        details.destination = details.destination / fs::path("sha256") / fs::path(digest.substr(digest.find(":") + 1));
         std::error_code error;
         if (fs::create_directories(details.destination, error); error)
         {
@@ -451,9 +460,10 @@ namespace core::oci
             resolve_queue.push_back(target);
             index++;
         }
-        logger->info("Creating Image Target Directory: {}");
 
-        logger->info("TOTAL ORDERS: {}", download_tasks.at(digest).size());
+        update.feed.append(fmt::format("Creating Image Target Directory: {}\n", details.destination.string()));
+        update.feed.append(fmt::format("layers to download:{}\n", download_tasks.at(digest).size()));
+        details.callback({}, update, {});
         resolve_layer();
     }
 

--- a/src/core/oci/oci_client.cc
+++ b/src/core/oci/oci_client.cc
@@ -102,7 +102,7 @@ namespace core::oci
 
     void oci_client::on_download_started(const std::string &image_digest, const std::string &layer_digest)
     {
-        logger->info("started download IMAGE: {} LAYER: {}", image_digest, layer_digest);
+        logger->trace("started download IMAGE: {} LAYER: {}", image_digest, layer_digest);
         // move to the next task
         // start_sequence.pop_front();
         // if (!start_sequence.empty())
@@ -478,7 +478,6 @@ namespace core::oci
             headers.emplace("Range", "bytes=0-");
             headers.emplace("Accept", target.media_type);
             headers.emplace("Authorization", fmt::format("Bearer {}", target.token));
-            logger->info("layer endpoint:{}", target.path);
             client->head(
                 target.path,
                 headers,

--- a/src/domain/containers/creation_handler.cc
+++ b/src/domain/containers/creation_handler.cc
@@ -1,197 +1,142 @@
 #include <domain/containers/creation_handler.h>
 #include <domain/containers/repository.h>
 #include <domain/containers/orders.h>
+#include <domain/containers/errors.h>
 #include <domain/images/helpers.h>
-#include <domain/images/payload.h>
-#include <domain/images/instructions/compression_errors.h>
-#include <domain/images/instructions/errors.h>
-#include <archive.h>
-#include <archive_entry.h>
-#include <fstream>
-#include <vector>
-#include <spdlog/spdlog.h>
+#include <core/archives/helper.h>
+#include <core/archives/errors.h>
 #include <fmt/format.h>
 #include <sole.hpp>
 
-namespace dmi = domain::images::instructions;
 namespace domain::containers
 {
+    std::map<std::string, std::string> extensions =
+        {
+            {".tar", "tar ball archive"},
+            {".tar.gz", "gunzip archive"},
+            {".tar.xz", "xzip arhive"}};
     creation_handler::creation_handler(
         core::connections::connection &connection,
         const fs::path &containers_folder,
         const fs::path &images_folder,
         std::shared_ptr<container_repository> repository) : command_handler(connection),
-                                                            identifier(sole::uuid4().str()),
                                                             containers_folder(containers_folder),
                                                             images_folder(images_folder),
-                                                            repository(std::move(repository)),
-                                                            frame{},
-                                                            logger(spdlog::get("jpod"))
+                                                            repository(std::move(repository))
     {
     }
-
     void creation_handler::on_order_received(const std::vector<uint8_t> &payload)
     {
-        auto order = unpack_container_creation_order(payload);
-        if (repository->exists(order.name))
+        auto identifier = sole::uuid4().str();
+        auto result = initialize_creation(identifier, repository, images_folder, containers_folder, payload)
+                          .and_then(extract_layers)
+                          .and_then(register_container);
+        if (!result)
         {
-            send_error(fmt::format("a container with the name: {} exists", order.name));
-        }
-        else if (auto query = dmi::resolve_tagged_image_details(order.tagged_image); !query)
-        {
-            send_error(dmi::make_error_code(dmi::error_code::invalid_order_issued));
-        }
-        else if (auto details = repository->fetch_image_details(query->registry, query->repository, query->tag); !details)
-        {
-            send_error(std::make_error_code(std::errc::resource_unavailable_try_again));
-        }
-        else if (auto error = initialize_decompression(details->identifier); error)
-        {
-            send_error(fmt::format("decompression of image failed: {}", error.message()));
-        }
-        else if (error = extract_filesystem(); error)
-        {
-            send_error(fmt::format("file system extraction failed: {}", error.message()));
+            auto target = containers_folder / fs::path(identifier);
+            fs::remove_all(target);
+            send_error(fmt::format("container creation failed: {}", result.error().message()));
         }
         else
         {
-            container_properties properties;
-            properties.identifier = identifier;
+            send_success(result.value()); // send the container ID over this call as the final response
+        }
+    }
+    creation_result creation_handler::initialize_creation(
+        std::string identifier,
+        std::shared_ptr<container_repository> store,
+        const fs::path &images_folder,
+        const fs::path &containers_folder,
+        const std::vector<uint8_t> &payload)
+    {
+        auto order = unpack_container_creation_order(payload);
+        auto target = containers_folder / fs::path(identifier);
+        std::error_code error{};
+        if (store->exists(order.name))
+        {
+            return tl::unexpected(make_container_failure(container_error::exists));
+        }
+        else if (auto result = images::instructions::resolve_tagged_image_details(order.tagged_image); !result)
+        {
+            return tl::unexpected(make_container_failure(container_error::invalid_image));
+        }
+        else if (auto image_identifier = store->fetch_image_identifier(result->registry, result->repository, result->tag); !image_identifier)
+        {
+            return tl::unexpected(make_container_failure(container_error::unknown_image));
+        }
+        else if (!fs::create_directories(target, error) && error)
+        {
+            return tl::make_unexpected(error);
+        }
+        else
+        {
+            creation_state state{};
+            state.name = order.name;
+            state.network_properties = order.network_properties;
+            state.env_vars.insert(order.env_vars.begin(), order.env_vars.end());
+            state.port_map.insert(order.port_map.begin(), order.port_map.end());
+            state.container_folder = target;
+            state.image_folder = images_folder;
+            state.image_identifier = image_identifier.value();
+            state.container_identifier = identifier;
+            state.store = store;
+            return state;
+        }
+    }
+    creation_result creation_handler::extract_layers(creation_state state)
+    {
+        fs::path image_folder = state.image_folder / fs::path(state.image_identifier);
+
+        if (auto out = core::archives::initialize_writer(); !out)
+        {
+            return tl::make_unexpected(make_container_failure(container_error::extraction_failed));
+        }
+        else
+        {
+            for (auto const &entry : fs::directory_iterator(image_folder))
+            {
+                if (entry.is_regular_file() && (extensions.find(entry.path().extension()) != extensions.end()))
+                {
+                    if (auto in = core::archives::initialize_reader(entry.path()); !in)
+                    {
+                        return tl::make_unexpected(make_container_failure(container_error::extraction_failed));
+                    }
+                    else if (auto error = core::archives::copy_to_destination(in.value(), out.value(), state.container_folder); error)
+                    {
+                        return tl::make_unexpected(error);
+                    }
+                }
+            }
+        }
+        return state;
+    }
+    tl::expected<std::string, std::error_code> creation_handler::register_container(creation_state state)
+    {
+        if (auto details = state.store->fetch_image_details(state.image_identifier); !details)
+        {
+            return tl::make_unexpected(make_container_failure(container_error::unknown_image));
+        }
+        else
+        {
+            container_properties properties{};
+            properties.identifier = state.container_identifier;
             properties.os = details->os;
-            properties.name = order.name;
+            properties.name = state.name;
             properties.image_identifier = details->identifier;
             properties.parameters.insert(details->parameters.begin(), details->parameters.end());
-            properties.port_map.insert(order.port_map.begin(), order.port_map.end());
+            properties.port_map.insert(state.port_map.begin(), state.port_map.end());
             properties.env_vars.insert(details->env_vars.begin(), details->env_vars.end());
-            properties.env_vars.insert(order.env_vars.begin(), order.env_vars.end());
+            properties.env_vars.insert(state.env_vars.begin(), state.env_vars.end());
             properties.entry_point = details->entry_point;
-            properties.network_properties = order.network_properties;
-            if (auto error = repository->save(properties); error)
+            properties.network_properties = state.network_properties;
+            if (auto error = state.store->save(properties); error)
             {
-                send_error(fmt::format("container creation failed: {}", error.message()));
-            }
-            else
-            {
-                send_success(identifier); // send the container ID over this call as the final response
+                return tl::make_unexpected(error);
             }
         }
+        return state.container_identifier;
     }
-    fs::path creation_handler::generate_container_folder(const std::string &identifier, std::error_code &error)
-    {
-        fs::path target = containers_folder / fs::path(identifier);
-        if (!fs::exists(target))
-        {
-            if (!fs::create_directories(target, error))
-            {
-                return "";
-            }
-        }
-        return target;
-    }
-    std::error_code creation_handler::extract_filesystem()
-    {
-        std::error_code error;
-        archive_entry *entry;
-        while (archive_read_next_header(input.get(), &entry) == ARCHIVE_OK)
-        {
-            const char *entry_name = archive_entry_pathname(entry);
-            const mode_t type = archive_entry_filetype(entry);
-            fs::path full_path = container_directory / fs::path(std::string(entry_name));
-            archive_entry_set_pathname(entry, full_path.generic_string().c_str());
-            if (auto ec = archive_write_header(output.get(), entry); ec != ARCHIVE_OK)
-            {
-                logger->error("{}", archive_error_string(output.get()));
-                return dmi::make_compression_error_code(ec);
-            }
-            else if (archive_entry_size(entry) > 0)
-            {
-                auto entry_size = archive_entry_size(entry);
-                if (error = copy_entry(input.get(), output.get()); error)
-                {
-                    return error;
-                }
-                frame.feed = fmt::format("unpacked: {}", std::string(entry_name));
-                send_progress(pack_progress_frame(frame));
-            }
-        }
-        return {};
-    }
-    fs::path creation_handler::fetch_image_archive(std::string &image_identifier, std::error_code &error)
-    {
-        fs::path target = images_folder / fs::path(image_identifier) / fs::path("fs.tar.gz");
-        if (!fs::exists(target, error))
-        {
-            return {};
-        }
-        return target;
-    }
-    std::error_code creation_handler::initialize_decompression(std::string &image_identifier)
-    {
-        int error_no;
-        std::error_code error;
-        if (container_directory = generate_container_folder(identifier, error); error)
-        {
-            logger->error("failed to create container folder");
-            return error;
-        }
-        else if (auto image_fs_archive = fetch_image_archive(image_identifier, error); error)
-        {
-            return error;
-        }
-        else
-        {
-            input = {
-                archive_read_new(),
-                [](archive *instance) -> void
-                {
-                    archive_read_close(instance);
-                    archive_read_free(instance);
-                }};
-            archive_read_support_filter_all(input.get());
-            archive_read_support_format_tar(input.get());
-            if (auto ec = archive_read_open_filename(input.get(), image_fs_archive.generic_string().c_str(), BUFFER_SIZE); ec != ARCHIVE_OK)
-            {
-                logger->error("{}", archive_error_string(input.get()));
-                return dmi::make_compression_error_code(ec);
-            }
-            output = {
-                archive_write_disk_new(),
-                [](archive *instance) -> void
-                {
-                    archive_write_close(instance);
-                    archive_write_free(instance);
-                }};
 
-            int flags = ARCHIVE_EXTRACT_TIME;
-            flags |= ARCHIVE_EXTRACT_PERM;
-            flags |= ARCHIVE_EXTRACT_ACL;
-            flags |= ARCHIVE_EXTRACT_FFLAGS;
-            archive_write_disk_set_options(output.get(), flags);
-            archive_write_disk_set_standard_lookup(output.get());
-            return {};
-        }
-    }
-    std::error_code creation_handler::copy_entry(struct archive *in, struct archive *out)
-    {
-        int ec;
-        const void *buffer;
-        std::size_t size;
-        la_int64_t offset;
-        while ((ec = archive_read_data_block(in, &buffer, &size, &offset)) == ARCHIVE_OK)
-        {
-            if (ec = archive_write_data_block(out, buffer, size, offset); ec != ARCHIVE_OK)
-            {
-                logger->error("{}", archive_error_string(out));
-                return dmi::make_compression_error_code(ec);
-            }
-        }
-        if (ec = archive_write_finish_entry(out); ec != ARCHIVE_OK)
-        {
-            logger->error("{}", archive_error_string(out));
-            return dmi::make_compression_error_code(ec);
-        }
-        return {};
-    }
     void creation_handler::on_connection_closed(const std::error_code &error) {}
 
     creation_handler::~creation_handler()

--- a/src/domain/images/import_handler.cc
+++ b/src/domain/images/import_handler.cc
@@ -20,8 +20,7 @@ namespace domain::images
                                    fs::path &image_folder,
                                    std::shared_ptr<image_repository> repository) : command_handler(connection),
                                                                                    image_folder(image_folder),
-                                                                                   repository(std::move(repository)),
-                                                                                   logger(spdlog::get("jpod"))
+                                                                                   repository(std::move(repository))
     {
     }
     void import_handler::on_order_received(const std::vector<uint8_t> &payload)
@@ -47,10 +46,10 @@ namespace domain::images
 
     void import_handler::on_connection_closed(const std::error_code &error)
     {
-        logger->info("connection closed");
     }
     import_result import_handler::initialize_state(std::shared_ptr<image_repository> repository, fs::path local_file_path, fs::path &image_folder)
     {
+
         if (auto result = core::archives::initialize_reader(local_file_path); !result)
         {
             return tl::make_unexpected(result.error());
@@ -58,130 +57,188 @@ namespace domain::images
         else
         {
             import_state state{};
+            state.image_archive = local_file_path;
             state.image_folder = image_folder;
             state.store = std::move(repository);
-            state.in = result.value();
+            state.logger = spdlog::get("jpod");
             return state;
         }
     }
     import_result import_handler::read_image_details(import_state state)
     {
-        archive_entry *entry = {};
-        while (archive_read_next_header(state.in.get(), &entry) == ARCHIVE_OK)
+        archive_entry *entry;
+        auto logger = state.logger;
+        uint32_t discovered_meta_details = 0;
+        int ec = 0;
+        if (auto result = core::archives::initialize_reader(state.image_archive); !result)
         {
-            const mode_t type = archive_entry_filetype(entry);
-            char const *current_entry_name = archive_entry_pathname(entry);
-            if ((S_ISREG(type)))
-            {
-                // read contents and entries
-                std::size_t file_size = archive_entry_size(entry);
-                if (std::strcmp(current_entry_name, MANIFEST.c_str()) == 0)
-                {
-                    state.manifest.reserve(file_size);
-
-                    if (auto ec = archive_read_data(state.in.get(), state.manifest.data(), file_size); ec < 0)
-                    {
-                        return tl::make_unexpected(core::archives::make_compression_error_code(ec));
-                    }
-                }
-                else if (std::strcmp(current_entry_name, INDEX.c_str()) == 0)
-                {
-                    state.index.reserve(file_size);
-
-                    if (auto ec = archive_read_data(state.in.get(), state.index.data(), file_size); ec < 0)
-                    {
-                        return tl::make_unexpected(core::archives::make_compression_error_code(ec));
-                    }
-                }
-            }
+            return tl::make_unexpected(result.error());
         }
+        else
+        {
+            auto in = result.value();
+            do
+            {
+                ec = archive_read_next_header(in.get(), &entry);
+                if (ec != ARCHIVE_OK && discovered_meta_details < 2)
+                {
+                    return tl::make_unexpected(core::archives::make_compression_error_code(ec));
+                }
+                const mode_t type = archive_entry_filetype(entry);
+                char const *current_entry_name = archive_entry_pathname(entry);
+                std::size_t file_size = archive_entry_size(entry);
+                if ((S_ISREG(type)) && std::strcmp(current_entry_name, MANIFEST.c_str()) == 0)
+                {
+                    logger->info("found image manifest of size: {}", file_size);
+                    std::vector<uint8_t> buffer(file_size);
+                    if (auto ec = archive_read_data(in.get(), &buffer[0], file_size); ec < 0)
+                    {
+                        return tl::make_unexpected(core::archives::make_compression_error_code(ec));
+                    }
+                    discovered_meta_details++;
+                    state.manifest.assign(buffer.begin(), buffer.end());
+                    logger->info("read in image manifest");
+                }
+                else if ((S_ISREG(type)) && std::strcmp(current_entry_name, INDEX.c_str()) == 0)
+                {
+                    logger->info("found image index of size: {}", file_size);
+                    std::vector<uint8_t> buffer(file_size);
+                    if (auto ec = archive_read_data(in.get(), &buffer[0], file_size); ec < 0)
+                    {
+                        return tl::make_unexpected(core::archives::make_compression_error_code(ec));
+                    }
+                    discovered_meta_details++;
+                    state.index.assign(buffer.begin(), buffer.end());
+                    logger->info("read in image index");
+                }
+            } while (ec == ARCHIVE_OK && discovered_meta_details < 2);
+        }
+        logger->info("finished picking up manifest and index information");
         return state;
     }
     import_result import_handler::extract_configuration(import_state state)
     {
-        auto manifest = json::parse(state.manifest);
+        auto logger = state.logger;
+        auto content = json::parse(std::string(state.manifest.begin(), state.manifest.end()));
         std::error_code error{};
         fs::path folder = state.image_folder / fs::path(state.identifier);
         if (fs::create_directories(folder, error); error)
         {
             return tl::make_unexpected(error);
         }
+        auto manifest = content.is_array() ? content[0] : content;
         state.entries.try_emplace(manifest["Config"].template get<std::string>(), folder / fs::path("config.json"));
-        int index = 1;
+        int index = 0;
         std::map<std::string, std::string> media_types;
-        for (const auto [key, value] : manifest["LayerSources"].items())
+        if (manifest.contains("LayerSources"))
         {
-            media_types.try_emplace(key, value["mediaType"].template get<std::string>());
-            state.size += value["size"].template get<std::size_t>();
+            logger->info("has layer sources");
+            for (const auto [key, value] : manifest["LayerSources"].items())
+            {
+                media_types.try_emplace(key, value["mediaType"].template get<std::string>());
+                state.size += value["size"].template get<std::size_t>();
+            }
+            logger->info("got details from layer sources");
         }
+        
         for (const auto &entry : manifest["Layers"])
         {
             auto path = entry.template get<std::string>();
             auto digest = fmt::format("sha256:{}", path.substr(path.find_last_of("/") + 1));
             auto media_type = media_types.at(digest);
-            auto extension = media_type.find_last_of(".tar+gzip") != std::string::npos ? "tar.gz" : "tar";
+            auto extension = media_type.find_last_of("tar+gzip") != std::string::npos ? "tar.gz" : "tar";
             auto file_path = fs::path(folder / fs::path(fmt::format("layer_{0}.{1}", index, extension)))
                                  .generic_string();
-            state.entries.try_emplace(path, folder / fs::path(fmt::format("layer")));
+            state.entries.try_emplace(path, file_path);
             index++;
         }
+
+        logger->info("extracted configuration details");
         return state;
     }
     import_result import_handler::extract_index(import_state state)
     {
-        auto index = json::parse(state.index);
+        auto logger = state.logger;
+        logger->info("extracting index details of size: {}", state.index.size());
+        logger->info("INDEX CONTENT: \n {}", std::string(state.index.begin(), state.index.end()));
+        auto index = json::parse(std::string(state.index.begin(), state.index.end()));
+        logger->info("parsed index");
         if (!index.contains("manifests") || index["manifests"].size() == 0)
         {
             return tl::make_unexpected(std::make_error_code(std::errc::no_link));
         }
         state.identifier = index["manifests"].at(0)["digest"].template get<std::string>();
+        logger->info("ID: {}", state.identifier);
         std::string header("sha256:");
         state.identifier.replace(0, header.size(), "");
-        auto name = index["manifests"].at(0)["annotations"]["io.containerd.image.name"].template get<std::string>();
-        state.tag = index["manifests"].at(0)["annotations"]["org.opencontainers.image.ref.name"].template get<std::string>();
-        state.repository = name.substr(0, name.find_last_of(":"));
+        if (index["manifests"].at(0).contains("annotations"))
+        {
+            auto annotations = index["manifests"].at(0)["annotations"];
+            auto name = annotations["io.containerd.image.name"].template get<std::string>();
+            state.tag = annotations["org.opencontainers.image.ref.name"].template get<std::string>();
+            state.repository = name.substr(0, name.find_last_of(":"));
+        } else 
+        {
+            state.repository.append("unknown");
+            state.registry.append("unknown");
+        }
+        logger->info("extracted index details");
         return state;
     }
     import_result import_handler::extract_image_content(import_state state)
     {
         int ec = 0;
-        archive_entry *entry = {};
-        do
+        archive_entry *entry;
+        if (auto result = core::archives::initialize_reader(state.image_archive); !result)
         {
-
-            if (auto ec = archive_read_next_header(state.in.get(), &entry); ec != ARCHIVE_OK)
+            return tl::make_unexpected(result.error());
+        }
+        else
+        {
+            auto logger = state.logger;
+            auto in = result.value();
+            logger->info("extracting layers");
+            while (archive_read_next_header(in.get(), &entry) == ARCHIVE_OK)
             {
-                return tl::make_unexpected(core::archives::make_compression_error_code(ec));
-            }
-            const mode_t type = archive_entry_filetype(entry);
-
-            if ((S_ISREG(type)))
-            {
+                const mode_t type = archive_entry_filetype(entry);
                 char const *current_entry_name = archive_entry_pathname(entry);
-                if (auto pos = state.entries.find(std::string(current_entry_name)); pos != state.entries.end())
+                if ((S_ISREG(type)))
                 {
-                    // now we can write file to desired destination
-                    std::ofstream stream(pos->second, std::ios::binary | std::ios::app);
-                    std::size_t chunk_size = 0L;
-                    std::vector<uint8_t> buffer(WRITE_BUFFER_SIZE);
-                    do
+                    if (auto pos = state.entries.find(std::string(current_entry_name)); pos != state.entries.end())
                     {
-                        if (chunk_size = archive_read_data(state.in.get(), buffer.data(), WRITE_BUFFER_SIZE); chunk_size > 0)
+                        logger->info("extracting: {} to {}", current_entry_name, pos->second.string());
+                        // now we can write file to desired destination
+                        std::ofstream stream(pos->second, std::ios::binary | std::ios::app);
+                        std::size_t chunk_size = 0L;
+                        std::vector<uint8_t> buffer(WRITE_BUFFER_SIZE);
+                        do
                         {
-                            stream.write(reinterpret_cast<const char *>(buffer.data()), chunk_size);
-                        }
-                    } while (chunk_size > 0);
+                            if (chunk_size = archive_read_data(in.get(), buffer.data(), WRITE_BUFFER_SIZE); chunk_size > 0)
+                            {
+                                stream.write(reinterpret_cast<const char *>(buffer.data()), chunk_size);
+                            }
+                        } while (chunk_size > 0);
+                    }
                 }
             }
-        } while (ec == ARCHIVE_OK);
+            logger->info("extracted all layers");
+        }
         return state;
     }
     import_result import_handler::resolve_image_meta(import_state state)
     {
+        auto logger = state.logger;
+        logger->info("resolving image metadata");
         fs::path file = state.image_folder / fs::path(state.identifier) / fs::path("config.json");
         std::ifstream stream(file);
-        auto payload = json::parse(stream)["config"];
+        if(!stream.is_open())
+        {
+            logger->warn("file is written and open");
+        } 
+        auto payload = json::parse(stream);
+        logger->info("got payload");
         state.os = payload["os"].template get<std::string>();
+        logger->info("OS: {}", state.os);
         auto configuration = payload["config"];
         if (configuration.contains("Labels") && configuration["Labels"].is_array())
         {

--- a/src/domain/images/pull_handler.cc
+++ b/src/domain/images/pull_handler.cc
@@ -46,7 +46,6 @@ namespace domain::images
         }
         else
         {
-            logger->info("GOT REG: AUTH-TYPE:{} AUTH-EP: {} REG-URL: {}", registry->authorization_type, registry->authorization_url, registry->uri);
             this->access_details.emplace(registry.value());
             this->credentials = order.credentials;
             this->repository = result->repository;
@@ -62,13 +61,12 @@ namespace domain::images
         core::oci::registry_credentials credentials{};
         credentials.name = std::string("docker");
         credentials.authorization_server = fmt::format("{}&scope=repository:{}:pull", access_details->authorization_url, repository);
-        logger->info("authorization to oci registry: {}", credentials.authorization_server);
         credentials.credentials = this->credentials;
         credentials.registry = access_details->uri;
         if (auto variation = core::oci::authorization_variant_from_str(access_details->authorization_type); variation)
         {
             credentials.variant = variation.value();
-            logger->info("matched for variation");
+            logger->trace("matched for variation");
         }
         client->authorize(credentials, std::bind(&pull_handler::on_authorization, this, _1));
     }
@@ -113,13 +111,11 @@ namespace domain::images
         }
         else
         {
-            logger->info("REGISTRY: {}", properties.registry);
             frame->feed = update.feed;
             frame->percentage = update.progress;
             send_progress(pack_progress_frame(*frame));
             if (update.complete)
             {
-                logger->info("completed image download");
                 std::string header("sha256:");
                 std::string image_identifier(properties.digest);
                 image_identifier.replace(0, header.size(), "");
@@ -137,7 +133,6 @@ namespace domain::images
     std::error_code pull_handler::save_image_details(const std::string identifier, const image_properties &properties)
     {
         image_details details{};
-        logger->info("image registry path: {}", properties.registry);
         details.identifier = identifier;
         details.registry = properties.registry;
         details.repository = properties.repository;

--- a/src/domain/images/pull_handler.cc
+++ b/src/domain/images/pull_handler.cc
@@ -1,0 +1,140 @@
+#include <domain/images/pull_handler.h>
+#include <domain/images/errors.h>
+#include <domain/images/repository.h>
+#include <domain/images/helpers.h>
+#include <domain/images/payload.h>
+#include <core/oci/oci_client.h>
+#include <core/oci/payloads.h>
+#include <sys/utsname.h>
+#include <system_error>
+#include <spdlog/spdlog.h>
+
+using namespace std::placeholders;
+
+namespace domain::images
+{
+    pull_handler::pull_handler(
+        core::connections::connection &connection,
+        std::shared_ptr<image_repository> repository,
+        oci_client_provider provider,
+        const fs::path &image_folder) : command_handler(connection),
+                                        provider(provider),
+                                        repository(std::move(repository)),
+                                        image_folder(image_folder),
+                                        client(nullptr),
+                                        frame(std::make_unique<progress_frame>()),
+                                        layer_progress{},
+                                        logger(spdlog::get("jpod"))
+    {
+    }
+
+    void pull_handler::on_order_received(const std::vector<uint8_t> &payload)
+    {
+        auto order = unpack_image_term_order(payload);
+        if (auto result = instructions::resolve_tagged_image_details(order.term); !result)
+        {
+            send_error(make_error_code(error_code::invalid_order));
+        }
+        else if (repository->has_image(result->registry, result->repository, result->tag))
+        {
+            send_error(make_error_code(error_code::already_exists));
+        }
+        else if (auto registry = repository->fetch_registry_by_path(result->registry); !registry)
+        {
+            send_error(make_error_code(error_code::unknown_registry));
+        }
+        else
+        {
+            fetch_oci_image(registry.value(), result->repository, result->tag);
+        }
+    }
+    void pull_handler::on_connection_closed(const std::error_code &error)
+    {
+    }
+    void pull_handler::fetch_oci_image(const registry_access_details &details, const std::string &repository, const std::string &tag)
+    {
+        image_fetch_order order{};
+        utsname machine_details;
+
+        if (uname(&machine_details) != 0)
+        {
+            send_error(std::error_code(errno, std::system_category()));
+        }
+        else
+        {
+            order.architecture = std::string(machine_details.machine);
+            order.registry = details.uri;
+            order.repository = repository;
+            order.tag = tag;
+            order.operating_system = tag.find("freebsd") != std::string::npos ? "freebsd" : "linux";
+            order.destination = image_folder;
+            client = provider();
+            client->fetch_image(order, std::bind(&pull_handler::on_image_download, this, _1, _2, _3));
+        }
+    }
+    void pull_handler::on_image_download(const std::error_code &error, const progress_update &update, const image_properties &properties)
+    {
+        // this is where the details will be tracked and persisted
+        // track the pair of image digest and layer digest
+        if (error)
+        {
+            send_error(error);
+        }
+        else if (layer_progress.find(update.layer_digest) == layer_progress.end())
+        {
+            layer_progress.try_emplace(update.layer_digest, update.progress);
+        }
+        else
+        {
+            layer_progress.try_emplace(update.layer_digest, update.progress);
+            frame->feed = update.feed;
+            frame->percentage = update.progress;
+            send_progress(pack_progress_frame(*frame));
+            if (layer_progress.size() == update.total_layers)
+            {
+                // verify completion condition by summing up and dividing to get 100
+                uint16_t sum = 0;
+                for (const auto &[_, progress] : layer_progress)
+                {
+                    sum += progress;
+                }
+                if (sum == static_cast<uint16_t>(update.total_layers) * 100)
+                {
+                    // complete
+                    // save details on image
+                    std::string header("sha256:");
+                    std::string image_identifier(properties.digest);
+                    image_identifier.replace(0, header.size(), "");
+                    if (auto error = save_image_details(image_identifier, properties); error)
+                    {
+                        send_error(error);
+                    }
+                    else
+                    {
+                        send_success(image_identifier);
+                    }
+                }
+            }
+        }
+    }
+    std::error_code pull_handler::save_image_details(const std::string identifier, const image_properties &properties)
+    {
+        image_details details{};
+        details.identifier = identifier;
+        details.registry = properties.registry;
+        details.repository = properties.repository;
+        details.tag = properties.tag;
+        details.size = properties.size;
+        details.os = properties.os;
+        details.variant = properties.variant;
+        details.version = properties.version;
+        details.labels.insert(properties.labels.begin(), properties.labels.end());
+        details.volumes.assign(properties.volumes.begin(), properties.volumes.end());
+        details.env_vars.insert(properties.env_vars.begin(), properties.env_vars.end());
+        details.exposed_ports.insert(properties.exposed_ports.begin(), properties.exposed_ports.end());
+        return repository->save_image_details(details);
+    }
+    pull_handler::~pull_handler()
+    {
+    }
+}

--- a/src/domain/images/pull_handler.cc
+++ b/src/domain/images/pull_handler.cc
@@ -7,6 +7,7 @@
 #include <core/oci/payloads.h>
 #include <sys/utsname.h>
 #include <system_error>
+#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
 using namespace std::placeholders;
@@ -15,43 +16,64 @@ namespace domain::images
 {
     pull_handler::pull_handler(
         core::connections::connection &connection,
-        std::shared_ptr<image_repository> repository,
+        std::shared_ptr<image_repository> store,
         oci_client_provider provider,
         const fs::path &image_folder) : command_handler(connection),
                                         provider(provider),
-                                        repository(std::move(repository)),
+                                        store(std::move(store)),
                                         image_folder(image_folder),
                                         client(nullptr),
                                         frame(std::make_unique<progress_frame>()),
                                         layer_progress{},
                                         logger(spdlog::get("jpod"))
     {
+        client = provider();
     }
 
     void pull_handler::on_order_received(const std::vector<uint8_t> &payload)
     {
-        auto order = unpack_image_term_order(payload);
-        if (auto result = instructions::resolve_tagged_image_details(order.term); !result)
+        auto order = unpack_pull_order(payload);
+        if (auto result = instructions::resolve_tagged_image_details(order.target); !result)
         {
             send_error(make_error_code(error_code::invalid_order));
         }
-        else if (repository->has_image(result->registry, result->repository, result->tag))
+        else if (store->has_image(result->registry, result->repository, result->tag))
         {
             send_error(make_error_code(error_code::already_exists));
         }
-        else if (auto registry = repository->fetch_registry_by_path(result->registry); !registry)
+        else if (auto registry = store->fetch_registry_by_path(result->registry); !registry)
         {
             send_error(make_error_code(error_code::unknown_registry));
         }
         else
         {
-            fetch_oci_image(registry.value(), result->repository, result->tag);
+            logger->info("GOT REG: AUTH-TYPE:{} AUTH-EP: {} REG-URL: {}", registry->authorization_type, registry->authorization_url, registry->uri);
+            this->access_details.emplace(registry.value());
+            this->credentials = order.credentials;
+            this->repository = result->repository;
+            this->tag = result->tag;
+            authorize_client();
         }
     }
     void pull_handler::on_connection_closed(const std::error_code &error)
     {
     }
-    void pull_handler::fetch_oci_image(const registry_access_details &details, const std::string &repository, const std::string &tag)
+    void pull_handler::authorize_client()
+    {
+        core::oci::registry_credentials credentials{};
+        credentials.name = std::string("docker");
+        credentials.authorization_server = fmt::format("{}&scope=repository:{}:pull", access_details->authorization_url, repository);
+        logger->info("authorization to oci registry: {}", credentials.authorization_server);
+        credentials.credentials = this->credentials;
+        credentials.registry = access_details->uri;
+        if (auto variation = core::oci::authorization_variant_from_str(access_details->authorization_type); variation)
+        {
+            credentials.variant = variation.value();
+            logger->info("matched for variation");
+        }
+        client->authorize(credentials, std::bind(&pull_handler::on_authorization, this, _1));
+    }
+    void pull_handler::fetch_oci_image()
     {
         image_fetch_order order{};
         utsname machine_details;
@@ -63,13 +85,25 @@ namespace domain::images
         else
         {
             order.architecture = std::string(machine_details.machine);
-            order.registry = details.uri;
+            logger->info("deduced architecture: {}", order.architecture);
+            order.registry = access_details->uri;
             order.repository = repository;
             order.tag = tag;
             order.operating_system = tag.find("freebsd") != std::string::npos ? "freebsd" : "linux";
             order.destination = image_folder;
-            client = provider();
             client->fetch_image(order, std::bind(&pull_handler::on_image_download, this, _1, _2, _3));
+        }
+    }
+    void pull_handler::on_authorization(const std::error_code &error)
+    {
+        if (error)
+        {
+            logger->error("failed to authorize:{}", error.message());
+            send_error(error);
+        }
+        else
+        {
+            fetch_oci_image();
         }
     }
     void pull_handler::on_image_download(const std::error_code &error, const progress_update &update, const image_properties &properties)
@@ -132,7 +166,7 @@ namespace domain::images
         details.volumes.assign(properties.volumes.begin(), properties.volumes.end());
         details.env_vars.insert(properties.env_vars.begin(), properties.env_vars.end());
         details.exposed_ports.insert(properties.exposed_ports.begin(), properties.exposed_ports.end());
-        return repository->save_image_details(details);
+        return store->save_image_details(details);
     }
     pull_handler::~pull_handler()
     {

--- a/src/domain/images/sql_repository.cc
+++ b/src/domain/images/sql_repository.cc
@@ -114,7 +114,7 @@ namespace domain::images
     std::error_code sql_image_repository::save_image_details(const image_details &details)
     {
         std::string sql("INSERT INTO image_tb(identifier, repository, tag, os, variant, version, size, internals, registry_id) "
-                        "VALUES(?, ?, ?, ?, ?, ?, ?, ?, (SELECT r.id FROM registry_tb AS r WHERE r.path = ?))");
+                        "VALUES(?, ?, ?, ?, ?, ?, ?, ?, (SELECT r.id FROM registry_tb AS r WHERE r.uri = ?))");
 
         auto connection = data_source.connection();
         core::sql::transaction txn(connection);

--- a/src/domain/images/sql_repository.cc
+++ b/src/domain/images/sql_repository.cc
@@ -55,7 +55,8 @@ namespace domain::images
     {
         std::string sql("SELECT "
                         "r.uri, "
-                        "r.token "
+                        "r.authorization_type, "
+                        "r.authorization_url "
                         "FROM registry_tb AS r "
                         "WHERE r.path = ?");
         auto connection = data_source.connection();
@@ -68,14 +69,16 @@ namespace domain::images
         }
         registry_access_details details{};
         details.uri = result.fetch<std::string>("uri");
-        details.token = result.fetch<std::string>("token");
+        details.authorization_type = result.fetch<std::string>("authorization_type");
+        details.authorization_url = result.fetch<std::string>("authorization_url");
         return std::make_optional(details);
     }
     std::optional<registry_access_details> sql_image_repository::fetch_registry_by_name(const std::string &name)
     {
         std::string sql("SELECT "
                         "r.uri, "
-                        "r.token "
+                        "r.authorization_type, "
+                        "r.authorization_url "
                         "FROM registry_tb AS r "
                         "WHERE r.name = ?");
         auto connection = data_source.connection();
@@ -88,7 +91,8 @@ namespace domain::images
         }
         registry_access_details details{};
         details.uri = result.fetch<std::string>("uri");
-        details.token = result.fetch<std::string>("token");
+        details.authorization_type = result.fetch<std::string>("authorization_type");
+        details.authorization_url = result.fetch<std::string>("authorization_url");
         return std::make_optional(details);
     }
     bool sql_image_repository::has_image(const std::string &registry, const std::string &name, const std::string &tag)

--- a/src/domain/networking/freebsd/freebsd_network_handler.cc
+++ b/src/domain/networking/freebsd/freebsd_network_handler.cc
@@ -73,7 +73,7 @@ namespace domain::networking::freebsd
                 return std::error_code(errno, std::system_category());
             }
             address_details details{order.name, order.ip, order.broadcast, order.netmask};
-            logger->info("adding address details");
+            logger->trace("adding address details");
             return add_address(fd, details);
         }
     }


### PR DESCRIPTION
Instead of extractive an archive, the filesystem for the container is based of compressed `OCI` layers being extracted to the container filesystem folder.

This will be slow for large containers but, it is possible that a layered filesystem could be employed in the future to allow for the support of systems with `UFS` or equivalent.